### PR TITLE
Bump version

### DIFF
--- a/src/aesophia.app.src
+++ b/src/aesophia.app.src
@@ -1,6 +1,6 @@
 {application, aesophia,
  [{description, "Contract Language for Aethernity"},
-  {vsn, "0.0.1"},
+  {vsn, "1.2.0"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
For next Roma release we want to point to this version of the compiler (not consensus breaking, but small changes)