### PR TITLE
Fix calldata creation for contracts involving oracles

### DIFF
--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -1655,6 +1655,7 @@ unify1(_Env, A, B, When) ->
                 Kind = fun({qcon, _, _})       -> con;
                           ({con, _, _})        -> con;
                           ({id, _, "address"}) -> addr;
+                          ({id, _, "hash"})    -> hash;
                           ({app_t, _, {id, _, "oracle"}, _})       -> oracle;
                           ({app_t, _, {id, _, "oracle_query"}, _}) -> query;
                           (_)                  -> other end,

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -494,19 +494,7 @@ infer(Contracts) ->
 -type option() :: permissive_address_literals | return_env.
 
 -spec init_env(list(option())) -> env().
-init_env(Options) ->
-    case proplists:get_value(permissive_address_literals, Options, false) of
-        false -> global_env();
-        true ->
-            %% Treat oracle and query ids as address to allow address literals for these
-            Ann = [{origin, system}],
-            Tag = fun(Tag, Val) -> {Tag, Ann, Val} end,
-            lists:foldl(fun({Name, Arity}, E) ->
-                            bind_type(Name, [{origin, system}],
-                                {lists:duplicate(Arity, Tag(tvar, "_")),
-                                    {alias_t, Tag(id, "address")}}, E)
-                        end, global_env(), [{"oracle", 2}, {"oracle_query", 2}])
-    end.
+init_env(_Options) -> global_env().
 
 -spec infer(aeso_syntax:ast(), list(option())) -> aeso_syntax:ast() | {env(), aeso_syntax:ast()}.
 infer(Contracts, Options) ->
@@ -1667,9 +1655,15 @@ unify1(_Env, A, B, When) ->
                 Kind = fun({qcon, _, _})       -> con;
                           ({con, _, _})        -> con;
                           ({id, _, "address"}) -> addr;
+                          ({app_t, _, {id, _, "oracle"}, _})       -> oracle;
+                          ({app_t, _, {id, _, "oracle_query"}, _}) -> query;
                           (_)                  -> other end,
-                %% If permissive_address_literals we allow unifying contract types and address
-                [addr, con] == lists:usort([Kind(A), Kind(B)]);
+                %% If permissive_address_literals we allow unifying adresses
+                %% with contract types or oracles/oracle queries
+                case lists:usort([Kind(A), Kind(B)]) of
+                    [addr, K] -> K /= other;
+                    _ -> false
+                end;
             false -> false
         end,
     [ cannot_unify(A, B, When) || not Ok ],

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -68,20 +68,13 @@ from_string(ContractBin, Options) when is_binary(ContractBin) ->
     from_string(binary_to_list(ContractBin), Options);
 from_string(ContractString, Options) ->
     try
-        Ast = parse(ContractString, Options),
-        ok = pp_sophia_code(Ast, Options),
-        ok = pp_ast(Ast, Options),
-        TypedAst = aeso_ast_infer_types:infer(Ast, Options),
-        %% pp_types is handled inside aeso_ast_infer_types.
-        ok = pp_typed_ast(TypedAst, Options),
-        ICode = to_icode(TypedAst, Options),
-        TypeInfo = extract_type_info(ICode),
-        ok = pp_icode(ICode, Options),
-        Assembler =  assemble(ICode, Options),
-        ok = pp_assembler(Assembler, Options),
+        #{icode := Icode} = string_to_icode(ContractString, Options),
+        TypeInfo  = extract_type_info(Icode),
+        Assembler = assemble(Icode, Options),
+        pp_assembler(Assembler, Options),
         ByteCodeList = to_bytecode(Assembler, Options),
         ByteCode = << << B:8 >> || B <- ByteCodeList >>,
-        ok = pp_bytecode(ByteCode, Options),
+        pp_bytecode(ByteCode, Options),
         {ok, #{byte_code => ByteCode,
                compiler_version => version(),
                contract_source => ContractString,
@@ -98,6 +91,18 @@ from_string(ContractString, Options) ->
                                 fun (E) -> io_lib:format("~p", [E]) end)}
         %% General programming errors in the compiler just signal error.
     end.
+
+string_to_icode(ContractString, Options) ->
+    Ast = parse(ContractString, Options),
+    pp_sophia_code(Ast, Options),
+    pp_ast(Ast, Options),
+    {TypeEnv, TypedAst} = aeso_ast_infer_types:infer(Ast, [return_env | Options]),
+    pp_typed_ast(TypedAst, Options),
+    Icode = ast_to_icode(TypedAst, Options),
+    pp_icode(Icode, Options),
+    #{ typed_ast => TypedAst,
+       type_env  => TypeEnv,
+       icode     => Icode }.
 
 join_errors(Prefix, Errors, Pfun) ->
     Ess = [ Pfun(E) || E <- Errors ],
@@ -132,20 +137,17 @@ check_call(Source, FunName, Args, Options) ->
 
 check_call(ContractString0, FunName, Args, Options, PatchFun) ->
     try
+        %% First check the contract without the __call function and no permissive literals
+        #{} = string_to_icode(ContractString0, Options),
         ContractString = insert_call_function(ContractString0, FunName, Args, Options),
-        Ast = parse(ContractString, Options),
-        ok = pp_sophia_code(Ast, Options),
-        ok = pp_ast(Ast, Options),
-        TypedAst = aeso_ast_infer_types:infer(Ast, [permissive_address_literals]),
+        #{typed_ast := TypedAst,
+          icode     := Icode} = string_to_icode(ContractString, [permissive_address_literals | Options]),
         {ok, {FunName, {fun_t, _, _, ArgTypes, RetType}}} = get_call_type(TypedAst),
-        ok = pp_typed_ast(TypedAst, Options),
-        Icode = to_icode(TypedAst, Options),
         ArgVMTypes = [ aeso_ast_to_icode:ast_typerep(T, Icode) || T <- ArgTypes ],
         RetVMType  = case RetType of
                          {id, _, "_"} -> any;
                          _            -> aeso_ast_to_icode:ast_typerep(RetType, Icode)
                      end,
-        ok = pp_icode(Icode, Options),
         #{ functions := Funs } = Icode,
         ArgIcode = get_arg_icode(Funs),
         ArgTerms = [ icode_to_term(T, Arg) ||
@@ -208,16 +210,12 @@ to_sophia_value(_, _, revert, Data, _Options) ->
     end;
 to_sophia_value(ContractString, FunName, ok, Data, Options) ->
     try
-        Ast = parse(ContractString, Options),
-        ok = pp_sophia_code(Ast, Options),
-        ok = pp_ast(Ast, Options),
-        {Env, TypedAst} = aeso_ast_infer_types:infer(Ast, [return_env]),
-        ok = pp_typed_ast(TypedAst, Options),
+        #{ typed_ast := TypedAst,
+           type_env  := TypeEnv,
+           icode     := Icode } = string_to_icode(ContractString, Options),
         {ok, Type0} = get_decode_type(FunName, TypedAst),
-        Type = aeso_ast_infer_types:unfold_types_in_type(Env, Type0, [unfold_record_types, unfold_variant_types]),
-        Icode = to_icode(TypedAst, Options),
+        Type   = aeso_ast_infer_types:unfold_types_in_type(TypeEnv, Type0, [unfold_record_types, unfold_variant_types]),
         VmType = aeso_ast_to_icode:ast_typerep(Type, Icode),
-        ok = pp_icode(Icode, Options),
         case aeso_heap:from_binary(VmType, Data) of
             {ok, VmValue} ->
                 try
@@ -374,7 +372,7 @@ icode_to_term(T, V) ->
 icodes_to_terms(Ts, Vs) ->
     [ icode_to_term(T, V) || {T, V} <- lists:zip(Ts, Vs) ].
 
-to_icode(TypedAst, Options) ->
+ast_to_icode(TypedAst, Options) ->
     aeso_ast_to_icode:convert_typed(TypedAst, Options).
 
 assemble(Icode, Options) ->

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -117,7 +117,7 @@ join_errors(Prefix, Errors, Pfun) ->
 %% terms for the arguments.
 %% NOTE: Special treatment for "init" since it might be implicit and has
 %%       a special return type (typerep, T)
--spec check_call(string(), string(), [string()], options()) -> {ok, string(), {[Type], Type | any}, [term()]} | {error, term()}
+-spec check_call(string(), string(), [string()], options()) -> {ok, string(), {[Type], Type}, [term()]} | {error, term()}
     when Type :: term().
 check_call(Source, "init" = FunName, Args, Options) ->
     PatchFun = fun(T) -> {tuple, [typerep, T]} end,

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -92,11 +92,13 @@ from_string(ContractString, Options) ->
         %% General programming errors in the compiler just signal error.
     end.
 
-string_to_icode(ContractString, Options) ->
+-spec string_to_icode(string(), [option() | permissive_address_literals]) -> map().
+string_to_icode(ContractString, Options0) ->
+    {InferOptions, Options} = lists:partition(fun(Opt) -> Opt == permissive_address_literals end, Options0),
     Ast = parse(ContractString, Options),
     pp_sophia_code(Ast, Options),
     pp_ast(Ast, Options),
-    {TypeEnv, TypedAst} = aeso_ast_infer_types:infer(Ast, [return_env | Options]),
+    {TypeEnv, TypedAst} = aeso_ast_infer_types:infer(Ast, [return_env | InferOptions]),
     pp_typed_ast(TypedAst, Options),
     Icode = ast_to_icode(TypedAst, Options),
     pp_icode(Icode, Options),

--- a/src/aeso_parser.erl
+++ b/src/aeso_parser.erl
@@ -68,9 +68,14 @@ decl() ->
 modifiers() ->
     many(choice([token(stateful), token(public), token(private), token(internal)])).
 
-add_modifiers(Mods, Node) ->
-    lists:foldl(fun({Mod, _}, X) -> set_ann(Mod, true, X) end,
-                Node, Mods).
+add_modifiers([], Node) -> Node;
+add_modifiers(Mods = [Tok | _], Node) ->
+    %% Set the position to the position of the first modifier. This is
+    %% important for code transformation tools (like what we do in
+    %% create_calldata) to be able to get the indentation of the declaration.
+    set_pos(get_pos(Tok),
+        lists:foldl(fun({Mod, _}, X) -> set_ann(Mod, true, X) end,
+                    Node, Mods)).
 
 %% -- Type declarations ------------------------------------------------------
 

--- a/src/aeso_pretty.erl
+++ b/src/aeso_pretty.erl
@@ -320,6 +320,7 @@ expr_p(_, E = {int, _, N}) ->
     text(S);
 expr_p(_, {bool, _, B}) -> text(atom_to_list(B));
 expr_p(_, {hash, _, <<N:256>>}) -> text("#" ++ integer_to_list(N, 16));
+expr_p(_, {hash, _, <<N:512>>}) -> text("#" ++ integer_to_list(N, 16));
 expr_p(_, {unit, _}) -> text("()");
 expr_p(_, {string, _, S}) -> term(binary_to_list(S));
 expr_p(_, {char, _, C}) ->

--- a/test/aeso_abi_tests.erl
+++ b/test/aeso_abi_tests.erl
@@ -97,6 +97,7 @@ calldata_test() ->
     Map = #{ <<"a">> => 4 },
     [{variant, 1, [Map]}, {{<<"b">>, 5}, {variant, 0, []}}] =
         encode_decode_calldata("foo", ["variant", "r"], ["Blue({[\"a\"] = 4})", "{x = (\"b\", 5), y = Red}"]),
+    [16#123, 16#456] = encode_decode_calldata("foo", ["hash", "address"], ["#123", "#456"]),
     ok.
 
 calldata_init_test() ->


### PR DESCRIPTION
There was a bug in the handling of oracles and oracle queries when building calldata