### PR TITLE
Add Auth.tx_hash - namespace + primop

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [ {aebytecode, {git, "https://github.com/aeternity/aebytecode.git",
-                             {ref,"2d599df"}}}
+                            {ref, "9041423"}}}
        , {getopt, "1.0.1"}
        , {jsx, {git, "https://github.com/talentdeficit/jsx.git",
                      {tag, "2.8.0"}}}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-       {ref,"2d599df0ea059df597a49e140e7100b0e8585cd9"}},
+       {ref,"9041423906247a7267a5a94530307b19c4490e8c"}},
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -443,8 +443,13 @@ global_env() ->
                       {"sha256",   Fun1(A, Hash)},
                       {"blake2b",  Fun1(A, Hash)}]) },
 
-     %% Strings
-     StringScope = #scope
+    %% Authentication
+    AuthScope = #scope
+        { funs = MkDefs(
+                     [{"tx_hash", Option(Hash)}]) },
+
+    %% Strings
+    StringScope = #scope
         { funs = MkDefs(
                      [{"length",  Fun1(String, Int)},
                       {"concat",  Fun([String, String], String)},
@@ -452,8 +457,8 @@ global_env() ->
                       {"sha256",  Fun1(String, Hash)},
                       {"blake2b", Fun1(String, Hash)}]) },
 
-     %% Bits
-     BitsScope = #scope
+    %% Bits
+    BitsScope = #scope
         { funs = MkDefs(
                      [{"set",          Fun([Bits, Int], Bits)},
                       {"clear",        Fun([Bits, Int], Bits)},
@@ -465,9 +470,9 @@ global_env() ->
                       {"none",         Bits},
                       {"all",          Bits}]) },
 
-     %% Conversion
-     IntScope     = #scope{ funs = MkDefs([{"to_str", Fun1(Int,     String)}]) },
-     AddressScope = #scope{ funs = MkDefs([{"to_str", Fun1(Address, String)}]) },
+    %% Conversion
+    IntScope     = #scope{ funs = MkDefs([{"to_str", Fun1(Int,     String)}]) },
+    AddressScope = #scope{ funs = MkDefs([{"to_str", Fun1(Address, String)}]) },
 
     #env{ scopes =
             #{ []           => TopScope
@@ -477,6 +482,7 @@ global_env() ->
              , ["Oracle"]   => OracleScope
              , ["AENS"]     => AENSScope
              , ["Map"]      => MapScope
+             , ["Auth"]     => AuthScope
              , ["Crypto"]   => CryptoScope
              , ["String"]   => StringScope
              , ["Bits"]     => BitsScope

--- a/src/aeso_ast_to_icode.erl
+++ b/src/aeso_ast_to_icode.erl
@@ -182,6 +182,11 @@ ast_body(?id_app("abort", [String], _, _), Icode) ->
     #funcall{ function = #var_ref{ name = {builtin, abort} },
               args     = [ast_body(String, Icode)] };
 
+%% Authentication
+ast_body({qid, _, ["Auth", "tx_hash"]}, _Icode) ->
+    prim_call(?PRIM_CALL_AUTH_TX_HASH, #integer{value = 0},
+              [], [], aeso_icode:option_typerep(word));
+
 %% Oracles
 ast_body(?qid_app(["Oracle", "register"], Args, _, ?oracle_t(QType, RType)), Icode) ->
     {Sign, [Acct, QFee, TTL]} = get_signature_arg(Args),

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -97,7 +97,8 @@ compilable_contracts() ->
      "variant_types",
      "state_handling",
      "events",
-     "include"
+     "include",
+     "basic_auth"
     ].
 
 %% Contracts that should produce type errors

--- a/test/contracts/basic_auth.aes
+++ b/test/contracts/basic_auth.aes
@@ -1,0 +1,19 @@
+// Contract replicating "normal" Aeternity authentication
+contract BasicAuth =
+  record state = { nonce : int, owner : address }
+
+  function init() = { nonce = 1, owner = Call.caller }
+
+  function authorize(n : int, s : signature) : bool =
+    require(n >= state.nonce, "Nonce too low")
+    require(n =< state.nonce, "Nonce too high")
+    put(state{ nonce = n + 1 })
+    switch(Auth.tx_hash)
+      None          => abort("Not in Auth context")
+      Some(tx_hash) => Crypto.ecverify(to_sign(tx_hash, n), state.owner, s)
+
+  function to_sign(h : hash, n : int) =
+    Crypto.blake2b((h, n))
+
+  private function require(b : bool, err : string) =
+    if(!b) abort(err)


### PR DESCRIPTION
Adds a new "builtin" namespace `Auth` that (at the moment) has one member `tx_hash`. `Auth.tx_hash` returns a `option(hash)` where `Some(hash)` is returned in Generalized account's authentication context, and `none` otherwise.

Since we have no good mechanism for "hiding" new features - apart from keeping a feature branch - let's merge this. If nothing else it will stop people from using the soon to be reserved namespace `Auth` :-) 