### PR TITLE
Revert bytes(N) from icode/vm-types

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [ {aebytecode, {git, "https://github.com/aeternity/aebytecode.git",
-                            {ref, "e8253b0"}}}
+                            {ref, "1526ad3"}}}
        , {getopt, "1.0.1"}
        , {jsx, {git, "https://github.com/talentdeficit/jsx.git",
                      {tag, "2.8.0"}}}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-       {ref,"e8253b09709f1595d8bd6a1756a0ce93185c6518"}},
+       {ref,"1526ad3bf057e72a1714aea0430b001bd1d576c9"}},
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",

--- a/src/aeso_ast_to_icode.erl
+++ b/src/aeso_ast_to_icode.erl
@@ -696,11 +696,8 @@ ast_typerep({qid, _, Name}, Icode) ->
     lookup_type_id(Name, [], Icode);
 ast_typerep({con, _, _}, _) ->
     word;   %% Contract type
-ast_typerep({bytes_t, _, Len}, _) when Len =< 32 ->
-    word;
 ast_typerep({bytes_t, _, Len}, _) ->
-    Words = (31 + Len) div 32,
-    {tuple, lists:duplicate(Words, word)};
+    bytes_t(Len);
 ast_typerep({app_t, _, {id, _, Name}, Args}, Icode) ->
     ArgReps = [ ast_typerep(Arg, Icode) || Arg <- Args ],
     lookup_type_id(Name, ArgReps, Icode);

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -267,9 +267,9 @@ translate_vm_value(word, {con, _, _Name},                        N) -> address_l
 translate_vm_value(word, {id, _, "int"},     N) -> {int, [], N};
 translate_vm_value(word, {id, _, "bits"},    N) -> error({todo, bits, N});
 translate_vm_value(word, {id, _, "bool"},    N) -> {bool, [], N /= 0};
-translate_vm_value({bytes, Len}, {bytes_t, _, Len}, Val) when Len =< 32 ->
+translate_vm_value(word, {bytes_t, _, Len}, Val) when Len =< 32 ->
     {bytes, [], <<Val:Len/unit:8>>};
-translate_vm_value({bytes, Len}, {bytes_t, _, Len}, Val) ->
+translate_vm_value({tuple, _}, {bytes_t, _, Len}, Val) ->
     {bytes, [], binary:part(<< <<W:32/unit:8>> || W <- tuple_to_list(Val) >>, 0, Len)};
 translate_vm_value(string, {id, _, "string"}, S) -> {string, [], S};
 translate_vm_value({list, VmType}, {app_t, _, {id, _, "list"}, [Type]}, List) ->
@@ -403,10 +403,6 @@ icode_to_term(word, {integer, N}) -> N;
 icode_to_term(string, {tuple, [{integer, Len} | Words]}) ->
     <<Str:Len/binary, _/binary>> = << <<W:256>> || {integer, W} <- Words >>,
     Str;
-icode_to_term({bytes, Len}, {integer, Value}) when Len =< 32 ->
-    Value;
-icode_to_term({bytes, Len}, {tuple, Words}) when Len > 32->
-    list_to_tuple([W || {integer, W} <- Words]);
 icode_to_term({list, T}, {list, Vs}) ->
     [ icode_to_term(T, V) || V <- Vs ];
 icode_to_term({tuple, Ts}, {tuple, Vs}) ->


### PR DESCRIPTION
For backwards compatibility (mainly in primops) it isn't a great idea to introduce a new VM-type. Instead, encode `bytes(N)` as either `word` or `{tuple, [word,...]}`.