### PR TITLE
Private function revamp

### DIFF
--- a/src/aeso_aci.erl
+++ b/src/aeso_aci.erl
@@ -9,7 +9,9 @@
 
 -module(aeso_aci).
 
--export([ contract_interface/2
+-export([ file/2
+        , file/3
+        , contract_interface/2
         , contract_interface/3
 
         , render_aci_json/1
@@ -22,6 +24,18 @@
 -type json_text() :: binary().
 
 %% External API
+-spec file(aci_type(), string()) -> {ok, json() | string()} | {error, term()}.
+file(Type, File) ->
+    file(Type, File, []).
+
+file(Type, File, Options0) ->
+    Options = aeso_compiler:add_include_path(File, Options0),
+    case file:read_file(File) of
+        {ok, BinCode} ->
+            do_contract_interface(Type, binary_to_list(BinCode), Options);
+        {error, _} = Err -> Err
+    end.
+
 -spec contract_interface(aci_type(), string()) ->
     {ok, json() | string()} | {error, term()}.
 contract_interface(Type, ContractString) ->

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -1006,13 +1006,12 @@ add_fun_env(Env = #{ fun_env := FunEnv }, Decls) ->
     Env#{ fun_env := maps:merge(FunEnv, FunEnv1) }.
 
 make_fun_name(#{ context := Context }, Ann, Name) ->
-    Private = proplists:get_value(private, Ann, false) orelse
-              proplists:get_value(internal, Ann, false),
+    Entrypoint = proplists:get_value(entrypoint, Ann, false),
     case Context of
         {main_contract, Main} ->
-            if Private        -> {local_fun, [Main, Name]};
-               Name == "init" -> init;
-               true           -> {entrypoint, list_to_binary(Name)}
+            if Name == "init" -> init;
+               Entrypoint     -> {entrypoint, list_to_binary(Name)};
+               true           -> {local_fun, [Main, Name]}
             end;
         {namespace, Lib} ->
             {local_fun, [Lib, Name]}

--- a/src/aeso_ast_to_icode.erl
+++ b/src/aeso_ast_to_icode.erl
@@ -817,13 +817,11 @@ has_maps({list, T})     -> has_maps(T);
 has_maps({tuple, Ts})   -> lists:any(fun has_maps/1, Ts);
 has_maps({variant, Cs}) -> lists:any(fun has_maps/1, lists:append(Cs)).
 
-%% A function is private if marked 'private' or 'internal', or if it's not
-%% defined in the main contract name space. (NOTE: changes when we introduce
-%% inheritance).
+%% A function is private if not an 'entrypoint', or if it's not defined in the
+%% main contract name space. (NOTE: changes when we introduce inheritance).
 is_private(Ann, #{ contract_name := MainContract } = Icode) ->
     {_, _, CurrentNamespace} = aeso_icode:get_namespace(Icode),
-    proplists:get_value(private,  Ann, false) orelse
-    proplists:get_value(internal, Ann, false) orelse
+    not proplists:get_value(entrypoint, Ann, false) orelse
     MainContract /= CurrentNamespace.
 
 %% -------------------------------------------------------------------

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -253,7 +253,7 @@ insert_call_function(Code, Call, FunName, Args, Options) ->
         [ Code,
           "\n\n",
           lists:duplicate(Ind, " "),
-          "stateful function ", Call,"() = ", FunName, "(", string:join(Args, ","), ")\n"
+          "stateful entrypoint ", Call, "() = ", FunName, "(", string:join(Args, ","), ")\n"
         ]).
 
 -spec insert_init_function(string(), options()) -> string().
@@ -263,7 +263,7 @@ insert_init_function(Code, Options) ->
     lists:flatten(
         [ Code,
           "\n\n",
-          lists:duplicate(Ind, " "), "function init() = ()\n"
+          lists:duplicate(Ind, " "), "entrypoint init() = ()\n"
         ]).
 
 last_contract_indent(Decls) ->

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -21,6 +21,7 @@
         , decode_calldata/3  %% deprecated
         , decode_calldata/4
         , parse/2
+        , add_include_path/2
         ]).
 
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
@@ -65,17 +66,25 @@ version() ->
 
 -spec file(string()) -> {ok, map()} | {error, binary()}.
 file(Filename) ->
-    Dir = filename:dirname(Filename),
-    {ok, Cwd} = file:get_cwd(),
-    file(Filename, [{include, {file_system, [Cwd, Dir]}}]).
+    file(Filename, []).
 
 -spec file(string(), options()) -> {ok, map()} | {error, binary()}.
-file(File, Options) ->
+file(File, Options0) ->
+    Options = add_include_path(File, Options0),
     case read_contract(File) of
         {ok, Bin} -> from_string(Bin, [{src_file, File} | Options]);
         {error, Error} ->
 	    ErrorString = [File,": ",file:format_error(Error)],
 	    {error, join_errors("File errors", [ErrorString], fun(E) -> E end)}
+    end.
+
+add_include_path(File, Options) ->
+    case lists:keymember(include, 1, Options) of
+        true  -> Options;
+        false ->
+            Dir = filename:dirname(File),
+            {ok, Cwd} = file:get_cwd(),
+            [{include, {file_system, [Cwd, Dir]}} | Options]
     end.
 
 -spec from_string(binary() | string(), options()) -> {ok, map()} | {error, binary()}.

--- a/src/aeso_pretty.erl
+++ b/src/aeso_pretty.erl
@@ -153,13 +153,21 @@ decl({type_decl, _, T, Vars}) -> typedecl(alias_t, T, Vars);
 decl({type_def, _, T, Vars, Def}) ->
     Kind = element(1, Def),
     equals(typedecl(Kind, T, Vars), typedef(Def));
-decl({fun_decl, _, F, T}) ->
-    hsep(text("function"), typed(name(F), T));
+decl({fun_decl, Ann, F, T}) ->
+    Fun = case aeso_syntax:get_ann(entrypoint, Ann, false) of
+            true  -> text("entrypoint");
+            false -> text("function")
+          end,
+    hsep(Fun, typed(name(F), T));
 decl(D = {letfun, Attrs, _, _, _, _}) ->
-    Mod = fun({Mod, true}) when Mod == private; Mod == internal; Mod == public; Mod == stateful ->
+    Mod = fun({Mod, true}) when Mod == private; Mod == stateful ->
                             text(atom_to_list(Mod));
              (_) -> empty() end,
-    hsep(lists:map(Mod, Attrs) ++ [letdecl("function", D)]);
+    Fun = case aeso_syntax:get_ann(entrypoint, Attrs, false) of
+              true  -> "entrypoint";
+              false -> "function"
+          end,
+    hsep(lists:map(Mod, Attrs) ++ [letdecl(Fun, D)]);
 decl(D = {letval, _, _, _, _}) -> letdecl("let", D).
 
 -spec expr(aeso_syntax:expr(), options()) -> doc().

--- a/src/aeso_scan.erl
+++ b/src/aeso_scan.erl
@@ -37,7 +37,7 @@ lexer() ->
         , {"[^/*]+|[/*]", skip()} ],
 
     Keywords = ["contract", "include", "let", "switch", "type", "record", "datatype", "if", "elif", "else", "function",
-                "stateful", "true", "false", "mod", "public", "private", "indexed", "internal", "namespace"],
+                "stateful", "true", "false", "mod", "public", "entrypoint", "private", "indexed", "namespace"],
     KW = string:join(Keywords, "|"),
 
     Rules =

--- a/test/aeso_aci_tests.erl
+++ b/test/aeso_aci_tests.erl
@@ -15,7 +15,7 @@ test_contract(N) ->
 
 test_cases(1) ->
     Contract = <<"contract C =\n"
-		 "  function a(i : int) = i+1\n">>,
+		 "  entrypoint a(i : int) = i+1\n">>,
     MapACI = #{contract =>
 		   #{name => <<"C">>,
 		     type_defs => [],
@@ -27,13 +27,13 @@ test_cases(1) ->
 			    returns => <<"int">>,
 			    stateful => false}]}},
     DecACI = <<"contract C =\n"
-	       "  function a : (int) => int\n">>,
+	       "  entrypoint a : (int) => int\n">>,
     {Contract,MapACI,DecACI};
 
 test_cases(2) ->
     Contract = <<"contract C =\n"
 		 "  type allan = int\n"
-		 "  function a(i : allan) = i+1\n">>,
+		 "  entrypoint a(i : allan) = i+1\n">>,
     MapACI = #{contract =>
                        #{name => <<"C">>,
                          type_defs =>
@@ -49,14 +49,14 @@ test_cases(2) ->
                                 stateful => false}]}},
     DecACI = <<"contract C =\n"
                "  type allan = int\n"
-               "  function a : (C.allan) => int\n">>,
+               "  entrypoint a : (C.allan) => int\n">>,
     {Contract,MapACI,DecACI};
 test_cases(3) ->
     Contract = <<"contract C =\n"
                  "  type state = ()\n"
                  "  datatype event = SingleEventDefined\n"
 		 "  datatype bert('a) = Bin('a)\n"
-		 "  function a(i : bert(string)) = 1\n">>,
+		 "  entrypoint a(i : bert(string)) = 1\n">>,
     MapACI = #{contract =>
 		   #{functions =>
 			 [#{arguments =>
@@ -78,7 +78,7 @@ test_cases(3) ->
                "  type state = ()\n"
                "  datatype event = SingleEventDefined\n"
 	       "  datatype bert('a) = Bin('a)\n"
-	       "  function a : (C.bert(string)) => int\n">>,
+	       "  entrypoint a : (C.bert(string)) => int\n">>,
     {Contract,MapACI,DecACI}.
 
 %% Rounttrip

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -130,6 +130,9 @@ failing_contracts() ->
        [<<"Duplicate definitions of abort at\n"
           "  - (builtin location)\n"
           "  - line 14, column 3">>,
+        <<"Duplicate definitions of require at\n"
+          "  - (builtin location)\n"
+          "  - line 15, column 3">>,
         <<"Duplicate definitions of double_def at\n"
           "  - line 10, column 3\n"
           "  - line 11, column 3">>,
@@ -141,12 +144,12 @@ failing_contracts() ->
           "  - line 8, column 3">>,
         <<"Duplicate definitions of put at\n"
           "  - (builtin location)\n"
-          "  - line 15, column 3">>,
+          "  - line 16, column 3">>,
         <<"Duplicate definitions of state at\n"
           "  - (builtin location)\n"
-          "  - line 16, column 3">>]}
+          "  - line 17, column 3">>]}
     , {"type_errors",
-       [<<"Unbound variable zz at line 17, column 21">>,
+       [<<"Unbound variable zz at line 17, column 23">>,
         <<"Cannot unify int\n"
           "         and list(int)\n"
           "when checking the application at line 26, column 9 of\n"
@@ -157,18 +160,18 @@ failing_contracts() ->
         <<"Cannot unify string\n"
           "         and int\n"
           "when checking the assignment of the field\n"
-          "  x : map(string, string) (at line 9, column 46)\n"
+          "  x : map(string, string) (at line 9, column 48)\n"
           "to the old value __x and the new value\n"
           "  __x {[\"foo\"] @ x = x + 1} : map(string, int)">>,
         <<"Cannot unify int\n"
           "         and string\n"
-          "when checking the type of the expression at line 34, column 45\n"
+          "when checking the type of the expression at line 34, column 47\n"
           "  1 : int\n"
           "against the expected type\n"
           "  string">>,
         <<"Cannot unify string\n"
           "         and int\n"
-          "when checking the type of the expression at line 34, column 50\n"
+          "when checking the type of the expression at line 34, column 52\n"
           "  \"bla\" : string\n"
           "against the expected type\n"
           "  int">>,
@@ -180,7 +183,7 @@ failing_contracts() ->
           "  int">>,
         <<"Cannot unify string\n"
           "         and int\n"
-          "when checking the type of the expression at line 11, column 56\n"
+          "when checking the type of the expression at line 11, column 58\n"
           "  \"foo\" : string\n"
           "against the expected type\n"
           "  int">>,
@@ -190,23 +193,23 @@ failing_contracts() ->
           "  - w : int (at line 38, column 13)\n"
           "  - z : string (at line 39, column 10)">>,
         <<"Not a record type: string\n"
-          "arising from the projection of the field y (at line 22, column 38)">>,
+          "arising from the projection of the field y (at line 22, column 40)">>,
         <<"Not a record type: string\n"
-          "arising from an assignment of the field y (at line 21, column 42)">>,
+          "arising from an assignment of the field y (at line 21, column 44)">>,
         <<"Not a record type: string\n"
-          "arising from an assignment of the field y (at line 20, column 38)">>,
+          "arising from an assignment of the field y (at line 20, column 40)">>,
         <<"Not a record type: string\n"
-          "arising from an assignment of the field y (at line 19, column 35)">>,
-        <<"Ambiguous record type with field y (at line 13, column 25) could be one of\n"
+          "arising from an assignment of the field y (at line 19, column 37)">>,
+        <<"Ambiguous record type with field y (at line 13, column 27) could be one of\n"
           "  - r (at line 4, column 10)\n"
           "  - r' (at line 5, column 10)">>,
         <<"Repeated name x in pattern\n"
           "  x :: x (at line 26, column 7)">>,
-        <<"Repeated argument x to function repeated_arg (at line 44, column 12).">>,
-        <<"Repeated argument y to function repeated_arg (at line 44, column 12).">>,
-        <<"No record type with fields y, z (at line 14, column 22)">>,
-        <<"The field z is missing when constructing an element of type r2 (at line 15, column 24)">>,
-        <<"Record type r2 does not have field y (at line 15, column 22)">>,
+        <<"Repeated argument x to function repeated_arg (at line 44, column 14).">>,
+        <<"Repeated argument y to function repeated_arg (at line 44, column 14).">>,
+        <<"No record type with fields y, z (at line 14, column 24)">>,
+        <<"The field z is missing when constructing an element of type r2 (at line 15, column 26)">>,
+        <<"Record type r2 does not have field y (at line 15, column 24)">>,
         <<"Let binding at line 47, column 5 must be followed by an expression">>,
         <<"Let binding at line 50, column 5 must be followed by an expression">>,
         <<"Let binding at line 54, column 5 must be followed by an expression">>,
@@ -220,9 +223,9 @@ failing_contracts() ->
           "         and ()\n"
           "when checking that 'init' returns a value of type 'state' at line 5, column 3">>]}
     , {"missing_fields_in_record_expression",
-       [<<"The field x is missing when constructing an element of type r('a) (at line 7, column 40)">>,
-        <<"The field y is missing when constructing an element of type r(int) (at line 8, column 40)">>,
-        <<"The fields y, z are missing when constructing an element of type r('a) (at line 6, column 40)">>]}
+       [<<"The field x is missing when constructing an element of type r('a) (at line 7, column 42)">>,
+        <<"The field y is missing when constructing an element of type r(int) (at line 8, column 42)">>,
+        <<"The fields y, z are missing when constructing an element of type r('a) (at line 6, column 42)">>]}
     , {"namespace_clash",
        [<<"The contract Call (at line 4, column 10) has the same name as a namespace at (builtin location)">>]}
     , {"bad_events",
@@ -234,7 +237,7 @@ failing_contracts() ->
     , {"type_clash",
         [<<"Cannot unify int\n"
            "         and string\n"
-           "when checking the record projection at line 12, column 40\n"
+           "when checking the record projection at line 12, column 42\n"
            "  r.foo : (gas : int, value : int) => Remote.themap\n"
            "against the expected type\n"
            "  (gas : int, value : int) => map(string, int)">>]}
@@ -318,28 +321,36 @@ failing_contracts() ->
            "against the expected type\n"
            "  bytes(32)">>]}
     , {"stateful",
-       [<<"Cannot reference stateful function Chain.spend (at line 13, column 33)\nin the definition of non-stateful function fail1.">>,
-        <<"Cannot reference stateful function local_spend (at line 14, column 33)\nin the definition of non-stateful function fail2.">>,
+       [<<"Cannot reference stateful function Chain.spend (at line 13, column 35)\nin the definition of non-stateful function fail1.">>,
+        <<"Cannot reference stateful function local_spend (at line 14, column 35)\nin the definition of non-stateful function fail2.">>,
         <<"Cannot reference stateful function Chain.spend (at line 16, column 15)\nin the definition of non-stateful function fail3.">>,
         <<"Cannot reference stateful function Chain.spend (at line 20, column 31)\nin the definition of non-stateful function fail4.">>,
-        <<"Cannot reference stateful function Chain.spend (at line 35, column 53)\nin the definition of non-stateful function fail5.">>,
-        <<"Cannot pass non-zero value argument 1000 (at line 48, column 55)\nin the definition of non-stateful function fail6.">>,
-        <<"Cannot pass non-zero value argument 1000 (at line 49, column 54)\nin the definition of non-stateful function fail7.">>,
+        <<"Cannot reference stateful function Chain.spend (at line 35, column 45)\nin the definition of non-stateful function fail5.">>,
+        <<"Cannot pass non-zero value argument 1000 (at line 48, column 57)\nin the definition of non-stateful function fail6.">>,
+        <<"Cannot pass non-zero value argument 1000 (at line 49, column 56)\nin the definition of non-stateful function fail7.">>,
         <<"Cannot pass non-zero value argument 1000 (at line 52, column 17)\nin the definition of non-stateful function fail8.">>]}
     , {"bad_init_state_access",
        [<<"The init function should return the initial state as its result and cannot write the state,\n"
           "but it calls\n"
           "  - set_state (at line 11, column 5), which calls\n"
-          "  - roundabout (at line 8, column 36), which calls\n"
-          "  - put (at line 7, column 37)">>,
+          "  - roundabout (at line 8, column 38), which calls\n"
+          "  - put (at line 7, column 39)">>,
         <<"The init function should return the initial state as its result and cannot read the state,\n"
           "but it calls\n"
           "  - new_state (at line 12, column 5), which calls\n"
-          "  - state (at line 5, column 27)">>,
+          "  - state (at line 5, column 29)">>,
         <<"The init function should return the initial state as its result and cannot read the state,\n"
           "but it calls\n"
           "  - state (at line 13, column 13)">>]}
     , {"field_parse_error",
        [<<"line 6, column 1: In field_parse_error at 5:26:\n"
           "Cannot use nested fields or keys in record construction: p.x\n">>]}
+    , {"modifier_checks",
+       [<<"The function all_the_things (at line 11, column 3) cannot be both public and private.">>,
+        <<"Namespaces cannot contain entrypoints (at line 3, column 3). Use 'function' instead.">>,
+        <<"The contract Remote (at line 5, column 10) has no entrypoints. Since Sophia version 3.2, public\ncontract functions must be declared with the 'entrypoint' keyword instead of\n'function'.">>,
+        <<"The entrypoint wha (at line 12, column 3) cannot be private. Use 'function' instead.">>,
+        <<"Use 'entrypoint' for declaration of foo (at line 6, column 3):\n  entrypoint foo : () => ()">>,
+        <<"Use 'entrypoint' instead of 'function' for public function foo (at line 10, column 3):\n  entrypoint foo() = ()">>,
+        <<"Use 'entrypoint' instead of 'function' for public function foo (at line 6, column 3):\n  entrypoint foo : () => ()">>]}
     ].

--- a/test/contracts/address_chain.aes
+++ b/test/contracts/address_chain.aes
@@ -1,33 +1,33 @@
 contract Remote =
-  function main : (int) => ()
+  entrypoint main : (int) => ()
 
 contract AddrChain =
   type o_type = oracle(string, map(string, int))
   type oq_type = oracle_query(string, map(string, int))
 
-  function is_o(a : address) =
+  entrypoint is_o(a : address) =
     Address.is_oracle(a)
 
-  function is_c(a : address) =
+  entrypoint is_c(a : address) =
     Address.is_contract(a)
 
-//   function get_o(a : address) : option(o_type) =
+//   entrypoint get_o(a : address) : option(o_type) =
 //     Address.get_oracle(a)
 
-//   function get_c(a : address) : option(Remote) =
+//   entrypoint get_c(a : address) : option(Remote) =
 //     Address.get_contract(a)
 
-  function check_o(o : o_type) =
+  entrypoint check_o(o : o_type) =
     Oracle.check(o)
 
-  function check_oq(o : o_type, oq : oq_type) =
+  entrypoint check_oq(o : o_type, oq : oq_type) =
     Oracle.check_query(o, oq)
 
-//   function h_to_i(h : hash) : int =
+//   entrypoint h_to_i(h : hash) : int =
 //     Hash.to_int(h)
 
-//   function a_to_i(a : address) : int =
+//   entrypoint a_to_i(a : address) : int =
 //     Address.to_int(a) mod 10 ^ 16
 
-  function c_creator() : address =
+  entrypoint c_creator() : address =
     Contract.creator

--- a/test/contracts/address_literals.aes
+++ b/test/contracts/address_literals.aes
@@ -1,14 +1,14 @@
 
 contract Remote =
-  function foo : () => ()
+  entrypoint foo : () => ()
 
 contract AddressLiterals =
-  function addr() : address =
+  entrypoint addr() : address =
     ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt
-  function oracle() : oracle(int, bool) =
+  entrypoint oracle() : oracle(int, bool) =
     ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5
-  function query() : oracle_query(int, bool) =
+  entrypoint query() : oracle_query(int, bool) =
     oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY
-  function contr() : Remote =
+  entrypoint contr() : Remote =
     ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ
 

--- a/test/contracts/aens.aes
+++ b/test/contracts/aens.aes
@@ -3,29 +3,29 @@ contract AENSTest =
 
   // Name resolution
 
-  stateful function resolve_word(name : string, key : string) : option(address) =
+  stateful entrypoint resolve_word(name : string, key : string) : option(address) =
     AENS.resolve(name, key)
 
-  stateful function resolve_string(name : string, key : string) : option(string) =
+  stateful entrypoint resolve_string(name : string, key : string) : option(string) =
     AENS.resolve(name, key)
 
   // Transactions
 
-  stateful function preclaim(addr  : address,     // Claim on behalf of this account (can be Contract.address)
+  stateful entrypoint preclaim(addr  : address,     // Claim on behalf of this account (can be Contract.address)
                              chash : hash) : () = // Commitment hash
     AENS.preclaim(addr, chash)
 
-  stateful function signedPreclaim(addr  : address, // Claim on behalf of this account (can be Contract.address)
+  stateful entrypoint signedPreclaim(addr  : address, // Claim on behalf of this account (can be Contract.address)
                                    chash : hash,             // Commitment hash
                                    sign  : signature) : () = // Signed by addr (if not Contract.address)
     AENS.preclaim(addr, chash, signature = sign)
 
-  stateful function claim(addr : address,
+  stateful entrypoint claim(addr : address,
                           name : string,
                           salt : int) : () =
     AENS.claim(addr, name, salt)
 
-  stateful function signedClaim(addr : address,
+  stateful entrypoint signedClaim(addr : address,
                                 name : string,
                                 salt : int,
                                 sign : signature) : () =
@@ -33,22 +33,22 @@ contract AENSTest =
 
   // TODO: update() -- how to handle pointers?
 
-  stateful function transfer(owner     : address,
+  stateful entrypoint transfer(owner     : address,
                              new_owner : address,
                              name_hash : hash) : () =
     AENS.transfer(owner, new_owner, name_hash)
 
-  stateful function signedTransfer(owner     : address,
+  stateful entrypoint signedTransfer(owner     : address,
                                    new_owner : address,
                                    name_hash : hash,
                                    sign      : signature) : () =
     AENS.transfer(owner, new_owner, name_hash, signature = sign)
 
-  stateful function revoke(owner     : address,
+  stateful entrypoint revoke(owner     : address,
                            name_hash : hash) : () =
     AENS.revoke(owner, name_hash)
 
-  stateful function signedRevoke(owner     : address,
+  stateful entrypoint signedRevoke(owner     : address,
                                  name_hash : hash,
                                  sign      : signature) : () =
     AENS.revoke(owner, name_hash, signature = sign)

--- a/test/contracts/bad_address_literals.aes
+++ b/test/contracts/bad_address_literals.aes
@@ -1,33 +1,33 @@
 
 contract Remote =
-  function foo : () => ()
+  entrypoint foo : () => ()
 
 contract AddressLiterals =
-  function addr1() : bytes(32) =
+  entrypoint addr1() : bytes(32) =
     ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt
-  function addr2() : Remote =
+  entrypoint addr2() : Remote =
     ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt
-  function addr3() : oracle(int, bool) =
+  entrypoint addr3() : oracle(int, bool) =
     ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt
 
-  function oracle1() : oracle_query(int, bool) =
+  entrypoint oracle1() : oracle_query(int, bool) =
     ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5
-  function oracle2() : bytes(32) =
+  entrypoint oracle2() : bytes(32) =
     ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5
-  function oracle3() : Remote =
+  entrypoint oracle3() : Remote =
     ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5
 
-  function query1() : oracle(int, bool) =
+  entrypoint query1() : oracle(int, bool) =
     oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY
-  function query2() : bytes(32) =
+  entrypoint query2() : bytes(32) =
     oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY
-  function query3() : Remote =
+  entrypoint query3() : Remote =
     oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY
 
-  function contr1() : address =
+  entrypoint contr1() : address =
     ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ
-  function contr2() : oracle(int, bool) =
+  entrypoint contr2() : oracle(int, bool) =
     ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ
-  function contr3() : bytes(32) =
+  entrypoint contr3() : bytes(32) =
     ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ
 

--- a/test/contracts/bad_events.aes
+++ b/test/contracts/bad_events.aes
@@ -9,15 +9,15 @@ contract Events =
     | BadEvent1(indexed string)
     | BadEvent2(indexed alias_string)
 
-  function f1(x : int, y : string) =
+  entrypoint f1(x : int, y : string) =
     Chain.event(Event1(x, x+1, y))
 
-  function f2(s : string) =
+  entrypoint f2(s : string) =
     Chain.event(Event2(s, Call.caller))
 
-  function f3(x : int) =
+  entrypoint f3(x : int) =
     Chain.event(Event1(x, x + 2, Int.to_str(x + 7)))
 
-  function i2s(i : int) = Int.to_str(i)
-  function a2s(a : address) = Address.to_str(a)
+  entrypoint i2s(i : int) = Int.to_str(i)
+  entrypoint a2s(a : address) = Address.to_str(a)
 

--- a/test/contracts/bad_events2.aes
+++ b/test/contracts/bad_events2.aes
@@ -9,15 +9,15 @@ contract Events =
     | BadEvent1(string, string)
     | BadEvent2(indexed int, indexed int, indexed int, indexed address)
 
-  function f1(x : int, y : string) =
+  entrypoint f1(x : int, y : string) =
     Chain.event(Event1(x, x+1, y))
 
-  function f2(s : string) =
+  entrypoint f2(s : string) =
     Chain.event(Event2(s, Call.caller))
 
-  function f3(x : int) =
+  entrypoint f3(x : int) =
     Chain.event(Event1(x, x + 2, Int.to_str(x + 7)))
 
-  function i2s(i : int) = Int.to_str(i)
-  function a2s(a : address) = Address.to_str(a)
+  entrypoint i2s(i : int) = Int.to_str(i)
+  entrypoint a2s(a : address) = Address.to_str(a)
 

--- a/test/contracts/bad_include_and_ns.aes
+++ b/test/contracts/bad_include_and_ns.aes
@@ -3,4 +3,4 @@ contract Bad =
   namespace Foo =
     function foo() = 42
 
-  function foo() = 43
+  entrypoint foo() = 43

--- a/test/contracts/bad_init_state_access.aes
+++ b/test/contracts/bad_init_state_access.aes
@@ -2,12 +2,12 @@ contract BadInit =
 
   type state = int
 
-  function new_state(n) = state + n
+  entrypoint new_state(n) = state + n
 
-  stateful function roundabout(n) = put(n)
-  stateful function set_state(n) = roundabout(n)
+  stateful entrypoint roundabout(n) = put(n)
+  stateful entrypoint set_state(n) = roundabout(n)
 
-  stateful function init() =
+  stateful entrypoint init() =
     set_state(4)
     new_state(0)
     state + state

--- a/test/contracts/basic_auth.aes
+++ b/test/contracts/basic_auth.aes
@@ -2,9 +2,9 @@
 contract BasicAuth =
   record state = { nonce : int, owner : address }
 
-  function init() = { nonce = 1, owner = Call.caller }
+  entrypoint init() = { nonce = 1, owner = Call.caller }
 
-  stateful function authorize(n : int, s : signature) : bool =
+  stateful entrypoint authorize(n : int, s : signature) : bool =
     require(n >= state.nonce, "Nonce too low")
     require(n =< state.nonce, "Nonce too high")
     put(state{ nonce = n + 1 })
@@ -12,6 +12,6 @@ contract BasicAuth =
       None          => abort("Not in Auth context")
       Some(tx_hash) => Crypto.ecverify(to_sign(tx_hash, n), state.owner, s)
 
-  function to_sign(h : hash, n : int) =
+  entrypoint to_sign(h : hash, n : int) =
     Crypto.blake2b((h, n))
 

--- a/test/contracts/bitcoin_auth.aes
+++ b/test/contracts/bitcoin_auth.aes
@@ -1,9 +1,9 @@
 contract BitcoinAuth =
   record state = { nonce : int, owner : bytes(64) }
 
-  function init(owner' : bytes(64)) = { nonce = 1, owner = owner' }
+  entrypoint init(owner' : bytes(64)) = { nonce = 1, owner = owner' }
 
-  stateful function authorize(n : int, s : signature) : bool =
+  stateful entrypoint authorize(n : int, s : signature) : bool =
     require(n >= state.nonce, "Nonce too low")
     require(n =< state.nonce, "Nonce too high")
     put(state{ nonce = n + 1 })
@@ -11,6 +11,6 @@ contract BitcoinAuth =
       None          => abort("Not in Auth context")
       Some(tx_hash) => Crypto.ecverify_secp256k1(to_sign(tx_hash, n), state.owner, s)
 
-  function to_sign(h : hash, n : int) : hash =
+  entrypoint to_sign(h : hash, n : int) : hash =
     Crypto.blake2b((h, n))
 

--- a/test/contracts/builtin_bug.aes
+++ b/test/contracts/builtin_bug.aes
@@ -5,8 +5,8 @@ contract BuiltinBug =
 
   record state = {proofs : map(address, list(string))}
 
-  public function init() = {proofs = {}}
+  entrypoint init() = {proofs = {}}
 
-  public stateful function createProof(hash : string) =
+  stateful entrypoint createProof(hash : string) =
     put( state{ proofs[Call.caller] = hash :: state.proofs[Call.caller] } )
 

--- a/test/contracts/builtin_map_get_bug.aes
+++ b/test/contracts/builtin_map_get_bug.aes
@@ -1,12 +1,8 @@
 contract TestContract =
-  record state = { 
-    _allowed          : map(address, map(address, int))}
+  record state = {_allowed : map(address, map(address, int))}
 
-  public stateful function init() = {
-    _allowed = {}}
+  entrypoint init() = {_allowed = {}}
 
-  public stateful function approve(spender: address, value: int) : bool = 
-
+  stateful entrypoint approve(spender: address, value: int) : bool =
     put(state{_allowed[Call.caller][spender] = value})
-
     true

--- a/test/contracts/bytes_equality.aes
+++ b/test/contracts/bytes_equality.aes
@@ -1,18 +1,18 @@
 
 contract BytesEquality =
 
-  function eq16(a : bytes(16), b) = a == b
-  function ne16(a : bytes(16), b) = a != b
+  entrypoint eq16(a : bytes(16), b) = a == b
+  entrypoint ne16(a : bytes(16), b) = a != b
 
-  function eq32(a : bytes(32), b) = a == b
-  function ne32(a : bytes(32), b) = a != b
+  entrypoint eq32(a : bytes(32), b) = a == b
+  entrypoint ne32(a : bytes(32), b) = a != b
 
-  function eq47(a : bytes(47), b) = a == b
-  function ne47(a : bytes(47), b) = a != b
+  entrypoint eq47(a : bytes(47), b) = a == b
+  entrypoint ne47(a : bytes(47), b) = a != b
 
-  function eq64(a : bytes(64), b) = a == b
-  function ne64(a : bytes(64), b) = a != b
+  entrypoint eq64(a : bytes(64), b) = a == b
+  entrypoint ne64(a : bytes(64), b) = a != b
 
-  function eq65(a : bytes(65), b) = a == b
-  function ne65(a : bytes(65), b) = a != b
+  entrypoint eq65(a : bytes(65), b) = a == b
+  entrypoint ne65(a : bytes(65), b) = a != b
 

--- a/test/contracts/bytes_to_x.aes
+++ b/test/contracts/bytes_to_x.aes
@@ -1,8 +1,8 @@
 
 contract BytesToX =
 
-  function to_int(b : bytes(42)) : int = Bytes.to_int(b)
-  function to_str(b : bytes(12)) : string =
+  entrypoint to_int(b : bytes(42)) : int = Bytes.to_int(b)
+  entrypoint to_str(b : bytes(12)) : string =
     String.concat(Bytes.to_str(b), Bytes.to_str(#ffff))
-  function to_str_big(b : bytes(65)) : string =
+  entrypoint to_str_big(b : bytes(65)) : string =
     Bytes.to_str(b)

--- a/test/contracts/complex_types.aes
+++ b/test/contracts/complex_types.aes
@@ -1,78 +1,78 @@
 
 contract Remote =
-  function up_to       : (int)               => list(int)
-  function sum         : (list(int))         => int
-  function some_string : ()                  => string
-  function pair        : (int, string)       => (int, string)
-  function squares     : (int)               => list((int, int))
-  function filter_some : (list(option(int))) => list(int)
-  function all_some    : (list(option(int))) => option(list(int))
+  entrypoint up_to       : (int)               => list(int)
+  entrypoint sum         : (list(int))         => int
+  entrypoint some_string : ()                  => string
+  entrypoint pair        : (int, string)       => (int, string)
+  entrypoint squares     : (int)               => list((int, int))
+  entrypoint filter_some : (list(option(int))) => list(int)
+  entrypoint all_some    : (list(option(int))) => option(list(int))
 
 contract ComplexTypes =
 
   record state = { worker : Remote }
 
-  function init(worker) = {worker = worker}
+  entrypoint init(worker) = {worker = worker}
 
-  function sum_acc(xs, n) =
+  entrypoint sum_acc(xs, n) =
     switch(xs)
       []      => n
       x :: xs => sum_acc(xs, x + n)
 
   // Sum a list of integers
-  function sum(xs : list(int)) =
+  entrypoint sum(xs : list(int)) =
     sum_acc(xs, 0)
 
-  function up_to_acc(n, xs) =
+  entrypoint up_to_acc(n, xs) =
     switch(n)
       0 => xs
       _ => up_to_acc(n - 1, n :: xs)
 
-  function up_to(n) = up_to_acc(n, [])
+  entrypoint up_to(n) = up_to_acc(n, [])
 
   record answer('a) = {label : string, result : 'a}
 
-  function remote_triangle(worker, n) : answer(int) =
+  entrypoint remote_triangle(worker, n) : answer(int) =
     let xs = worker.up_to(gas = 100000, n)
     let t  = worker.sum(xs)
     { label = "answer:", result = t }
 
-  function remote_list(n) : list(int) =
+  entrypoint remote_list(n) : list(int) =
     state.worker.up_to(n)
 
-  function some_string() = "string"
+  entrypoint some_string() = "string"
 
-  function remote_string() : string =
+  entrypoint remote_string() : string =
     state.worker.some_string()
 
-  function pair(x : int, y : string) = (x, y)
+  entrypoint pair(x : int, y : string) = (x, y)
 
-  function remote_pair(n : int, s : string) : (int, string) =
+  entrypoint remote_pair(n : int, s : string) : (int, string) =
     state.worker.pair(gas = 10000, n, s)
 
-  function map(f, xs) =
+  entrypoint map(f, xs) =
     switch(xs)
       []      => []
       x :: xs => f(x) :: map(f, xs)
 
-  function squares(n) =
+  entrypoint squares(n) =
     map((i) => (i, i * i), up_to(n))
 
-  function remote_squares(n) : list((int, int)) =
+  entrypoint remote_squares(n) : list((int, int)) =
     state.worker.squares(n)
 
   // option types
 
-  function filter_some(xs : list(option(int))) : list(int) =
+  entrypoint filter_some(xs : list(option(int))) : list(int) =
     switch(xs)
       []            => []
       None    :: ys => filter_some(ys)
       Some(x) :: ys => x :: filter_some(ys)
 
-  function remote_filter_some(xs : list(option(int))) : list(int) =
+  entrypoint remote_filter_some(xs : list(option(int))) : list(int) =
     state.worker.filter_some(xs)
 
-  function all_some(xs : list(option(int))) : option(list(int)) =
+  entrypoint all_some(xs : list(option(int))) : option(list(int)) =
     switch(xs)
       []         => Some([])
       None :: ys => None
@@ -81,6 +81,6 @@ contract ComplexTypes =
           Some(xs) => Some(x :: xs)
           None     => None
 
-  function remote_all_some(xs : list(option(int))) : option(list(int)) =
+  entrypoint remote_all_some(xs : list(option(int))) : option(list(int)) =
     state.worker.all_some(gas = 10000, xs)
 

--- a/test/contracts/counter.aes
+++ b/test/contracts/counter.aes
@@ -3,7 +3,7 @@ contract Counter =
 
   record state = { value : int }
 
-  function init(val) = { value = val }
-  function get()     = state.value
-  stateful function tick()    = put(state{ value = state.value + 1 })
+  entrypoint init(val) = { value = val }
+  entrypoint get()     = state.value
+  stateful entrypoint tick()    = put(state{ value = state.value + 1 })
 

--- a/test/contracts/deadcode.aes
+++ b/test/contracts/deadcode.aes
@@ -13,9 +13,9 @@ namespace List =
 
 contract Deadcode =
 
-  function inc1(xs : list(int)) : list(int) =
+  entrypoint inc1(xs : list(int)) : list(int) =
     List.map1((x) => x + 1, xs)
 
-  function inc2(xs : list(int)) : list(int) =
+  entrypoint inc2(xs : list(int)) : list(int) =
     List.map1((x) => x + 1, xs)
 

--- a/test/contracts/dutch_auction.aes
+++ b/test/contracts/dutch_auction.aes
@@ -10,13 +10,13 @@ contract DutchAuction =
                    sold         : bool }
 
   // Add to work around current lack of predefined functions
-  private stateful function spend(to, amount) =
+  stateful function spend(to, amount) =
     let total = Contract.balance
     Chain.spend(to, amount)
     total - amount
 
   // TTL set by user on posting contract, typically (start - end ) div dec
-  public function init(beneficiary, start, decrease) : state =
+  entrypoint init(beneficiary, start, decrease) : state =
     require(start > 0 && decrease > 0, "bad args")
     { start_amount = start,
       start_height = Chain.block_height,
@@ -27,7 +27,7 @@ contract DutchAuction =
   // -- API
 
   // We are the buyer... interesting case to buy for someone else and keep 10%
-  public stateful function bid() =
+  stateful entrypoint bid() =
     require( !(state.sold), "sold")
     let cost =
       state.start_amount - (Chain.block_height - state.start_height) * state.dec

--- a/test/contracts/environment.aes
+++ b/test/contracts/environment.aes
@@ -1,69 +1,69 @@
 
 // Testing primitives for accessing the block chain environment
 contract Interface =
-  function contract_address : () => address
-  function call_origin      : () => address
-  function call_caller      : () => address
-  function call_value       : () => int
+  entrypoint contract_address : () => address
+  entrypoint call_origin      : () => address
+  entrypoint call_caller      : () => address
+  entrypoint call_value       : () => int
 
 contract Environment =
 
   record state = {remote : Interface}
 
-  function init(remote) = {remote = remote}
+  entrypoint init(remote) = {remote = remote}
 
-  stateful function set_remote(remote) = put({remote = remote})
+  stateful entrypoint set_remote(remote) = put({remote = remote})
 
   // -- Information about the this contract ---
 
   // Address
-  function contract_address() : address = Contract.address
-  function nested_address(who) : address =
+  entrypoint contract_address() : address = Contract.address
+  entrypoint nested_address(who) : address =
     who.contract_address(gas = 1000)
 
   // Balance
-  function contract_balance() : int = Contract.balance
+  entrypoint contract_balance() : int = Contract.balance
 
   // -- Information about the current call ---
 
   // Origin
-  function call_origin()   : address = Call.origin
-  function nested_origin() : address =
+  entrypoint call_origin()   : address = Call.origin
+  entrypoint nested_origin() : address =
     state.remote.call_origin()
 
   // Caller
-  function call_caller() : address = Call.caller
-  function nested_caller() : address =
+  entrypoint call_caller() : address = Call.caller
+  entrypoint nested_caller() : address =
     state.remote.call_caller()
 
   // Value
-  function call_value() : int = Call.value
-  stateful function nested_value(value : int) : int =
+  entrypoint call_value() : int = Call.value
+  stateful entrypoint nested_value(value : int) : int =
     state.remote.call_value(value = value / 2)
 
   // Gas price
-  function call_gas_price() : int = Call.gas_price
+  entrypoint call_gas_price() : int = Call.gas_price
 
   // -- Information about the chain ---
 
   // Account balances
-  function get_balance(acct : address) : int = Chain.balance(acct)
+  entrypoint get_balance(acct : address) : int = Chain.balance(acct)
 
   // Block hash
-  function block_hash(height : int) : option(hash) = Chain.block_hash(height)
+  entrypoint block_hash(height : int) : option(hash) = Chain.block_hash(height)
 
   // Coinbase
-  function coinbase() : address = Chain.coinbase
+  entrypoint coinbase() : address = Chain.coinbase
 
   // Block timestamp
-  function timestamp() : int = Chain.timestamp
+  entrypoint timestamp() : int = Chain.timestamp
 
   // Block height
-  function block_height() : int = Chain.block_height
+  entrypoint block_height() : int = Chain.block_height
 
   // Difficulty
-  function difficulty() : int = Chain.difficulty
+  entrypoint difficulty() : int = Chain.difficulty
 
   // Gas limit
-  function gas_limit() : int = Chain.gas_limit
+  entrypoint gas_limit() : int = Chain.gas_limit
 

--- a/test/contracts/events.aes
+++ b/test/contracts/events.aes
@@ -1,5 +1,5 @@
 contract Remote =
-  function dummy : () => ()
+  entrypoint dummy : () => ()
 
 contract Events =
 
@@ -29,12 +29,12 @@ contract Events =
     | Data2(ix8, data3, ix9)
     | Data3(ix1, ix2, ix5, data1)
 
-  function nodata0()                   = Chain.event(Nodata0)
-  function nodata1(ix1)                = Chain.event(Nodata1(ix1))
-  function nodata2(ix2, ix3)           = Chain.event(Nodata2(ix2, ix3))
-  function nodata3(ix4, ix5, ix6)      = Chain.event(Nodata3(ix4, ix5, ix6))
-  function data0(data1)                = Chain.event(Data0(data1))
-  function data1(data2, ix7)           = Chain.event(Data1(data2, ix7))
-  function data2(ix8, data3, ix9)      = Chain.event(Data2(ix8, data3, ix9))
-  function data3(ix1, ix2, ix5, data1) = Chain.event(Data3(ix1, ix2, ix5, data1))
+  entrypoint nodata0()                   = Chain.event(Nodata0)
+  entrypoint nodata1(ix1)                = Chain.event(Nodata1(ix1))
+  entrypoint nodata2(ix2, ix3)           = Chain.event(Nodata2(ix2, ix3))
+  entrypoint nodata3(ix4, ix5, ix6)      = Chain.event(Nodata3(ix4, ix5, ix6))
+  entrypoint data0(data1)                = Chain.event(Data0(data1))
+  entrypoint data1(data2, ix7)           = Chain.event(Data1(data2, ix7))
+  entrypoint data2(ix8, data3, ix9)      = Chain.event(Data2(ix8, data3, ix9))
+  entrypoint data3(ix1, ix2, ix5, data1) = Chain.event(Data3(ix1, ix2, ix5, data1))
 

--- a/test/contracts/factorial.aes
+++ b/test/contracts/factorial.aes
@@ -1,17 +1,17 @@
 // An implementation of the factorial function where each recursive
 // call is to another contract. Not the cheapest way to compute factorial.
 contract FactorialServer =
-  function fac : (int) => int
+  entrypoint fac : (int) => int
 
 contract Factorial =
 
   record state = {worker : FactorialServer}
 
-  function init(worker) = {worker = worker}
+  entrypoint init(worker) = {worker = worker}
 
-  stateful function set_worker(worker) = put(state{worker = worker})
+  stateful entrypoint set_worker(worker) = put(state{worker = worker})
 
-  function fac(x : int) : int =
+  entrypoint fac(x : int) : int =
     if(x == 0) 1
     else x * state.worker.fac(x - 1)
 

--- a/test/contracts/funargs.aes
+++ b/test/contracts/funargs.aes
@@ -1,47 +1,47 @@
 
 contract FunctionArguments =
 
-  function sum(n : int, m: int) =
+  entrypoint sum(n : int, m: int) =
     n + m
 
-  function append(xs : list(string)) =
+  entrypoint append(xs : list(string)) =
      switch(xs)
       []      => ""
       y :: ys => String.concat(y, append(ys))
 
-  function menot(b) =
+  entrypoint menot(b) =
     !b
 
-  function bitsum(b : bits) =
+  entrypoint bitsum(b : bits) =
     Bits.sum(b)
 
   record answer('a) = {label : string, result : 'a}
 
-  function read(a : answer(int)) =
+  entrypoint read(a : answer(int)) =
      a.result
 
-  function sjutton(b : bytes(17)) =
+  entrypoint sjutton(b : bytes(17)) =
      b
 
-  function sextiosju(b : bytes(67)) =
+  entrypoint sextiosju(b : bytes(67)) =
      b
 
-  function trettiotva(b : bytes(32)) =
+  entrypoint trettiotva(b : bytes(32)) =
      b
 
-  function find_oracle(o : oracle(int, bool)) =
+  entrypoint find_oracle(o : oracle(int, bool)) =
      true
 
-  function find_query(q : oracle_query(int, bool)) =
+  entrypoint find_query(q : oracle_query(int, bool)) =
      true
 
   datatype colour() = Green | Yellow | Red | Pantone(int)
 
-  function traffic_light(c : colour) =
+  entrypoint traffic_light(c : colour) =
      Red
 
-  function tuples(t : ()) =
+  entrypoint tuples(t : ()) =
      t
 
-  function due(t : Chain.ttl) =
+  entrypoint due(t : Chain.ttl) =
      true

--- a/test/contracts/functions.aes
+++ b/test/contracts/functions.aes
@@ -1,15 +1,15 @@
 contract Functions =
-  private function curry(f : ('a, 'b) => 'c) =
+  function curry(f : ('a, 'b) => 'c) =
     (x) => (y) => f(x, y)
-  private function map(f : 'a => 'b, xs : list('a)) =
+  function map(f : 'a => 'b, xs : list('a)) =
     switch(xs)
       [] => []
       x :: xs => f(x) :: map(f, xs)
-  private function map'() = map
-  private function plus(x, y) = x + y
-  function test1(xs : list(int)) = map(curry(plus)(5), xs)
-  function test2(xs : list(int)) = map'()(((x) => (y) => ((x, y) => x + y)(x, y))(100), xs)
-  function test3(xs : list(int)) =
+  function map'() = map
+  function plus(x, y) = x + y
+  entrypoint test1(xs : list(int)) = map(curry(plus)(5), xs)
+  entrypoint test2(xs : list(int)) = map'()(((x) => (y) => ((x, y) => x + y)(x, y))(100), xs)
+  entrypoint test3(xs : list(int)) =
     let m(f, xs) = map(f, xs)
     m((x) => x + 1, xs)
 

--- a/test/contracts/fundme.aes
+++ b/test/contracts/fundme.aes
@@ -12,20 +12,20 @@ contract FundMe =
                    deadline      : int,
                    goal          : int }
 
-  private stateful function spend(args : spend_args) =
+  stateful function spend(args : spend_args) =
     Chain.spend(args.recipient, args.amount)
 
-  public function init(beneficiary, deadline, goal) : state =
+  entrypoint init(beneficiary, deadline, goal) : state =
     { contributions = {},
       beneficiary   = beneficiary,
       deadline      = deadline,
       total         = 0,
       goal          = goal }
 
-  private function is_contributor(addr) =
+  function is_contributor(addr) =
     Map.member(addr, state.contributions)
 
-  public stateful function contribute() =
+  stateful entrypoint contribute() =
     if(Chain.block_height >= state.deadline)
       spend({ recipient = Call.caller, amount = Call.value }) // Refund money
       false
@@ -36,7 +36,7 @@ contract FundMe =
                  total @ tot = tot + Call.value })
       true
 
-  public stateful function withdraw() =
+  stateful entrypoint withdraw() =
     if(Chain.block_height < state.deadline)
       abort("Cannot withdraw before deadline")
     if(Call.caller == state.beneficiary)
@@ -46,13 +46,13 @@ contract FundMe =
     else
       abort("Not a contributor or beneficiary")
 
-  private stateful function withdraw_beneficiary() =
+  stateful function withdraw_beneficiary() =
     require(state.total >= state.goal, "Project was not funded")
     spend({recipient = state.beneficiary,
            amount    = Contract.balance })
     put(state{ beneficiary = ak_11111111111111111111111111111111273Yts })
 
-  private stateful function withdraw_contributor() =
+  stateful function withdraw_contributor() =
     if(state.total >= state.goal)
       abort("Project was funded")
     let to = Call.caller

--- a/test/contracts/identity.aes
+++ b/test/contracts/identity.aes
@@ -1,3 +1,3 @@
 
 contract Identity =
-  function main (x:int) = x
+  entrypoint main (x:int) = x

--- a/test/contracts/include.aes
+++ b/test/contracts/include.aes
@@ -2,8 +2,8 @@ include "included.aes"
 include "../contracts/included2.aes"
 
 contract Include =
-  function foo() =
+  entrypoint foo() =
     Included.foo() < Included2a.bar()
 
-  function bar() =
+  entrypoint bar() =
     Included2b.foo() > Included.foo()

--- a/test/contracts/init_type_error.aes
+++ b/test/contracts/init_type_error.aes
@@ -3,6 +3,6 @@ contract InitTypeError =
 
   type state = map(int, int)
 
-  // Check that the compiler catches ill-typed init function
-  function init() = "not the right type!"
+  // Check that the compiler catches ill-typed init entrypoint
+  entrypoint init() = "not the right type!"
 

--- a/test/contracts/maps.aes
+++ b/test/contracts/maps.aes
@@ -4,97 +4,97 @@ contract Maps =
   record state = { map_i : map(int, pt),
                    map_s : map(string, pt) }
 
-  function init() = { map_i = {}, map_s = {} }
+  entrypoint init() = { map_i = {}, map_s = {} }
 
-  function get_state() = state
+  entrypoint get_state() = state
 
   // {[k] = v}
-  function map_i() =
+  entrypoint map_i() =
     { [1] = {x = 1, y = 2},
       [2] = {x = 3, y = 4},
       [3] = {x = 5, y = 6} }
-  function map_s() =
+  entrypoint map_s() =
     { ["one"]   = {x = 1, y = 2},
       ["two"]   = {x = 3, y = 4},
       ["three"] = {x = 5, y = 6} }
-  stateful function map_state_i() = put(state{ map_i = map_i() })
-  stateful function map_state_s() = put(state{ map_s = map_s() })
+  stateful entrypoint map_state_i() = put(state{ map_i = map_i() })
+  stateful entrypoint map_state_s() = put(state{ map_s = map_s() })
 
   // m[k]
-  function get_i(k, m : map(int,    pt)) = m[k]
-  function get_s(k, m : map(string, pt)) = m[k]
-  function get_state_i(k) = get_i(k, state.map_i)
-  function get_state_s(k) = get_s(k, state.map_s)
+  entrypoint get_i(k, m : map(int,    pt)) = m[k]
+  entrypoint get_s(k, m : map(string, pt)) = m[k]
+  entrypoint get_state_i(k) = get_i(k, state.map_i)
+  entrypoint get_state_s(k) = get_s(k, state.map_s)
 
   // m[k = v]
-  function get_def_i(k, v, m : map(int,    pt)) = m[k = v]
-  function get_def_s(k, v, m : map(string, pt)) = m[k = v]
-  function get_def_state_i(k, v) = get_def_i(k, v, state.map_i)
-  function get_def_state_s(k, v) = get_def_s(k, v, state.map_s)
+  entrypoint get_def_i(k, v, m : map(int,    pt)) = m[k = v]
+  entrypoint get_def_s(k, v, m : map(string, pt)) = m[k = v]
+  entrypoint get_def_state_i(k, v) = get_def_i(k, v, state.map_i)
+  entrypoint get_def_state_s(k, v) = get_def_s(k, v, state.map_s)
 
   // m{[k] = v}
-  function set_i(k, p, m : map(int,    pt)) = m{ [k] = p }
-  function set_s(k, p, m : map(string, pt)) = m{ [k] = p }
-  stateful function set_state_i(k, p) = put(state{ map_i = set_i(k, p, state.map_i) })
-  stateful function set_state_s(k, p) = put(state{ map_s = set_s(k, p, state.map_s) })
+  entrypoint set_i(k, p, m : map(int,    pt)) = m{ [k] = p }
+  entrypoint set_s(k, p, m : map(string, pt)) = m{ [k] = p }
+  stateful entrypoint set_state_i(k, p) = put(state{ map_i = set_i(k, p, state.map_i) })
+  stateful entrypoint set_state_s(k, p) = put(state{ map_s = set_s(k, p, state.map_s) })
 
   // m{f[k].x = v}
-  function setx_i(k, x, m : map(int,    pt)) = m{ [k].x = x }
-  function setx_s(k, x, m : map(string, pt)) = m{ [k].x = x }
-  stateful function setx_state_i(k, x) = put(state{ map_i[k].x = x })
-  stateful function setx_state_s(k, x) = put(state{ map_s[k].x = x })
+  entrypoint setx_i(k, x, m : map(int,    pt)) = m{ [k].x = x }
+  entrypoint setx_s(k, x, m : map(string, pt)) = m{ [k].x = x }
+  stateful entrypoint setx_state_i(k, x) = put(state{ map_i[k].x = x })
+  stateful entrypoint setx_state_s(k, x) = put(state{ map_s[k].x = x })
 
   // m{[k] @ x = v }
-  function addx_i(k, d, m : map(int,    pt)) = m{ [k].x @ x = x + d }
-  function addx_s(k, d, m : map(string, pt)) = m{ [k].x @ x = x + d }
-  stateful function addx_state_i(k, d) = put(state{ map_i[k].x @ x = x + d })
-  stateful function addx_state_s(k, d) = put(state{ map_s[k].x @ x = x + d })
+  entrypoint addx_i(k, d, m : map(int,    pt)) = m{ [k].x @ x = x + d }
+  entrypoint addx_s(k, d, m : map(string, pt)) = m{ [k].x @ x = x + d }
+  stateful entrypoint addx_state_i(k, d) = put(state{ map_i[k].x @ x = x + d })
+  stateful entrypoint addx_state_s(k, d) = put(state{ map_s[k].x @ x = x + d })
 
   // m{[k = def] @ x = v }
-  function addx_def_i(k, v, d, m : map(int,    pt)) = m{ [k = v].x @ x = x + d }
-  function addx_def_s(k, v, d, m : map(string, pt)) = m{ [k = v].x @ x = x + d }
+  entrypoint addx_def_i(k, v, d, m : map(int,    pt)) = m{ [k = v].x @ x = x + d }
+  entrypoint addx_def_s(k, v, d, m : map(string, pt)) = m{ [k = v].x @ x = x + d }
 
   // Map.member
-  function member_i(k, m : map(int,    pt)) = Map.member(k, m)
-  function member_s(k, m : map(string, pt)) = Map.member(k, m)
-  function member_state_i(k) = member_i(k, state.map_i)
-  function member_state_s(k) = member_s(k, state.map_s)
+  entrypoint member_i(k, m : map(int,    pt)) = Map.member(k, m)
+  entrypoint member_s(k, m : map(string, pt)) = Map.member(k, m)
+  entrypoint member_state_i(k) = member_i(k, state.map_i)
+  entrypoint member_state_s(k) = member_s(k, state.map_s)
 
   // Map.lookup
-  function lookup_i(k, m : map(int,    pt)) = Map.lookup(k, m)
-  function lookup_s(k, m : map(string, pt)) = Map.lookup(k, m)
-  function lookup_state_i(k) = lookup_i(k, state.map_i)
-  function lookup_state_s(k) = lookup_s(k, state.map_s)
+  entrypoint lookup_i(k, m : map(int,    pt)) = Map.lookup(k, m)
+  entrypoint lookup_s(k, m : map(string, pt)) = Map.lookup(k, m)
+  entrypoint lookup_state_i(k) = lookup_i(k, state.map_i)
+  entrypoint lookup_state_s(k) = lookup_s(k, state.map_s)
 
   // Map.lookup_default
-  function lookup_def_i(k, m : map(int,    pt), def : pt) =
+  entrypoint lookup_def_i(k, m : map(int,    pt), def : pt) =
     Map.lookup_default(k, m, def)
-  function lookup_def_s(k, m : map(string, pt), def : pt) =
+  entrypoint lookup_def_s(k, m : map(string, pt), def : pt) =
     Map.lookup_default(k, m, def)
-  function lookup_def_state_i(k, def) = lookup_def_i(k, state.map_i, def)
-  function lookup_def_state_s(k, def) = lookup_def_s(k, state.map_s, def)
+  entrypoint lookup_def_state_i(k, def) = lookup_def_i(k, state.map_i, def)
+  entrypoint lookup_def_state_s(k, def) = lookup_def_s(k, state.map_s, def)
 
   // Map.delete
-  function delete_i(k, m : map(int,    pt)) = Map.delete(k, m)
-  function delete_s(k, m : map(string, pt)) = Map.delete(k, m)
-  stateful function delete_state_i(k) = put(state{ map_i = delete_i(k, state.map_i) })
-  stateful function delete_state_s(k) = put(state{ map_s = delete_s(k, state.map_s) })
+  entrypoint delete_i(k, m : map(int,    pt)) = Map.delete(k, m)
+  entrypoint delete_s(k, m : map(string, pt)) = Map.delete(k, m)
+  stateful entrypoint delete_state_i(k) = put(state{ map_i = delete_i(k, state.map_i) })
+  stateful entrypoint delete_state_s(k) = put(state{ map_s = delete_s(k, state.map_s) })
 
   // Map.size
-  function size_i(m : map(int,    pt)) = Map.size(m)
-  function size_s(m : map(string, pt)) = Map.size(m)
-  function size_state_i() = size_i(state.map_i)
-  function size_state_s() = size_s(state.map_s)
+  entrypoint size_i(m : map(int,    pt)) = Map.size(m)
+  entrypoint size_s(m : map(string, pt)) = Map.size(m)
+  entrypoint size_state_i() = size_i(state.map_i)
+  entrypoint size_state_s() = size_s(state.map_s)
 
   // Map.to_list
-  function tolist_i(m : map(int,    pt)) = Map.to_list(m)
-  function tolist_s(m : map(string, pt)) = Map.to_list(m)
-  function tolist_state_i() = tolist_i(state.map_i)
-  function tolist_state_s() = tolist_s(state.map_s)
+  entrypoint tolist_i(m : map(int,    pt)) = Map.to_list(m)
+  entrypoint tolist_s(m : map(string, pt)) = Map.to_list(m)
+  entrypoint tolist_state_i() = tolist_i(state.map_i)
+  entrypoint tolist_state_s() = tolist_s(state.map_s)
 
   // Map.from_list
-  function fromlist_i(xs : list((int,    pt))) = Map.from_list(xs)
-  function fromlist_s(xs : list((string, pt))) = Map.from_list(xs)
-  stateful function fromlist_state_i(xs) = put(state{ map_i = fromlist_i(xs) })
-  stateful function fromlist_state_s(xs) = put(state{ map_s = fromlist_s(xs) })
+  entrypoint fromlist_i(xs : list((int,    pt))) = Map.from_list(xs)
+  entrypoint fromlist_s(xs : list((string, pt))) = Map.from_list(xs)
+  stateful entrypoint fromlist_state_i(xs) = put(state{ map_i = fromlist_i(xs) })
+  stateful entrypoint fromlist_state_s(xs) = put(state{ map_s = fromlist_s(xs) })
 

--- a/test/contracts/missing_fields_in_record_expression.aes
+++ b/test/contracts/missing_fields_in_record_expression.aes
@@ -3,6 +3,6 @@ contract MissingFieldsInRecordExpr =
   record r('a) = {x : int, y : string, z : 'a}
   type alias('a) = r('a)
 
-  function fail1()               = { x = 0 }
-  function fail2(z : 'a) : r('a) = { y = "string", z = z }
-  function fail3() : alias(int)  = { x = 0, z = 1 }
+  entrypoint fail1()               = { x = 0 }
+  entrypoint fail2(z : 'a) : r('a) = { y = "string", z = z }
+  entrypoint fail3() : alias(int)  = { x = 0, z = 1 }

--- a/test/contracts/missing_state_type.aes
+++ b/test/contracts/missing_state_type.aes
@@ -2,5 +2,5 @@
 contract MissingStateType =
 
   // Check that we get a type error also for implicit state
-  function init() = "should be ()"
+  entrypoint init() = "should be ()"
 

--- a/test/contracts/modifier_checks.aes
+++ b/test/contracts/modifier_checks.aes
@@ -1,0 +1,12 @@
+
+namespace Lib =
+  entrypoint foo() = ()
+
+contract Remote =
+  public function foo : () => ()
+  function bla() = ()
+
+contract Contract =
+  public function foo() = ()
+  public private stateful function all_the_things() = ()
+  private entrypoint wha() = ()

--- a/test/contracts/name_clash.aes
+++ b/test/contracts/name_clash.aes
@@ -1,16 +1,17 @@
 
 contract NameClash =
 
-  function double_proto : () => int
-  function double_proto : () => int
+  entrypoint double_proto : () => int
+  entrypoint double_proto : () => int
 
-  function proto_and_def : int => int
-  function proto_and_def(n) = n + 1
+  entrypoint proto_and_def : int => int
+  entrypoint proto_and_def(n) = n + 1
 
-  function double_def(x) = x
-  function double_def(y) = 0
+  entrypoint double_def(x) = x
+  entrypoint double_def(y) = 0
 
-  // abort, put and state are builtin
-  function abort() : int = 0
-  function put(x) = x
-  function state(x, y) = x + y
+  // abort, require, put and state are builtin
+  entrypoint abort() : int = 0
+  entrypoint require(b, err) = if(b) abort(err)
+  entrypoint put(x) = x
+  entrypoint state(x, y) = x + y

--- a/test/contracts/namespace_bug.aes
+++ b/test/contracts/namespace_bug.aes
@@ -8,11 +8,11 @@ namespace Foo =
 contract Bug =
 
   // Crashed the type checker
-  function foo() = Foo.bar()
+  entrypoint foo() = Foo.bar()
 
   // Also crashed the type checker
   type t = Foo.bla
 
-  function test() =
+  entrypoint test() =
     let x : t = Foo.bar()
     x

--- a/test/contracts/namespace_clash.aes
+++ b/test/contracts/namespace_clash.aes
@@ -2,4 +2,4 @@
 // You can't shadow existing contracts or namespaces.
 
 contract Call =
-  function whatever() = ()
+  entrypoint whatever() = ()

--- a/test/contracts/nodeadcode.aes
+++ b/test/contracts/nodeadcode.aes
@@ -13,9 +13,9 @@ namespace List =
 
 contract Deadcode =
 
-  function inc1(xs : list(int)) : list(int) =
+  entrypoint inc1(xs : list(int)) : list(int) =
     List.map1((x) => x + 1, xs)
 
-  function inc2(xs : list(int)) : list(int) =
+  entrypoint inc2(xs : list(int)) : list(int) =
     List.map2((x) => x + 1, xs)
 

--- a/test/contracts/oracles.aes
+++ b/test/contracts/oracles.aes
@@ -9,31 +9,31 @@ contract Oracles =
   type oracle_id = oracle(query_t, answer_t)
   type query_id  = oracle_query(query_t, answer_t)
 
-  stateful function registerOracle(acct : address,
+  stateful entrypoint registerOracle(acct : address,
                           qfee : fee,
                           ttl  : ttl) : oracle_id =
      Oracle.register(acct, qfee, ttl)
 
-  stateful function registerIntIntOracle(acct : address,
+  stateful entrypoint registerIntIntOracle(acct : address,
                                 qfee : fee,
                                 ttl  : ttl) : oracle(int, int) =
      Oracle.register(acct, qfee, ttl)
 
-  stateful function registerStringStringOracle(acct : address,
+  stateful entrypoint registerStringStringOracle(acct : address,
                                       qfee : fee,
                                       ttl  : ttl) : oracle(string, string) =
      Oracle.register(acct, qfee, ttl)
 
-  stateful function signedRegisterOracle(acct : address,
+  stateful entrypoint signedRegisterOracle(acct : address,
                                 sign : signature,
                                 qfee : fee,
                                 ttl  : ttl) : oracle_id =
      Oracle.register(acct, qfee, ttl, signature = sign)
 
-  function queryFee(o : oracle_id) : fee =
+  entrypoint queryFee(o : oracle_id) : fee =
     Oracle.query_fee(o)
 
-  stateful function createQuery(o    : oracle_id,
+  stateful entrypoint createQuery(o    : oracle_id,
                        q    : query_t,
                        qfee : fee,
                        qttl : ttl,
@@ -42,7 +42,7 @@ contract Oracles =
     Oracle.query(o, q, qfee, qttl, rttl)
 
   // Do not use in production!
-  stateful function unsafeCreateQuery(o    : oracle_id,
+  stateful entrypoint unsafeCreateQuery(o    : oracle_id,
                        q    : query_t,
                        qfee : fee,
                        qttl : ttl,
@@ -50,7 +50,7 @@ contract Oracles =
     Oracle.query(o, q, qfee, qttl, rttl)
 
   // Do not use in production!
-  stateful function unsafeCreateQueryThenErr(o    : oracle_id,
+  stateful entrypoint unsafeCreateQueryThenErr(o    : oracle_id,
                        q    : query_t,
                        qfee : fee,
                        qttl : ttl,
@@ -59,50 +59,50 @@ contract Oracles =
     require(qfee >= 100000000000000000, "causing a late error")
     res
 
-  stateful function extendOracle(o    : oracle_id,
+  stateful entrypoint extendOracle(o    : oracle_id,
                         ttl  : ttl) : () =
     Oracle.extend(o, ttl)
 
-  stateful function signedExtendOracle(o    : oracle_id,
+  stateful entrypoint signedExtendOracle(o    : oracle_id,
                               sign : signature,   // Signed oracle address
                               ttl  : ttl) : () =
     Oracle.extend(o, signature = sign, ttl)
 
-  stateful function respond(o    : oracle_id,
+  stateful entrypoint respond(o    : oracle_id,
                    q    : query_id,
                    r    : answer_t) : () =
     Oracle.respond(o, q, r)
 
-  stateful function signedRespond(o    : oracle_id,
+  stateful entrypoint signedRespond(o    : oracle_id,
                          q    : query_id,
                          sign : signature,
                          r    : answer_t) : () =
     Oracle.respond(o, q, signature = sign, r)
 
-  function getQuestion(o : oracle_id,
+  entrypoint getQuestion(o : oracle_id,
                        q : query_id) : query_t =
     Oracle.get_question(o, q)
 
-  function hasAnswer(o : oracle_id,
+  entrypoint hasAnswer(o : oracle_id,
                      q : query_id) =
     switch(Oracle.get_answer(o, q))
       None    => false
       Some(_) => true
 
-  function getAnswer(o : oracle_id,
+  entrypoint getAnswer(o : oracle_id,
                      q : query_id) : option(answer_t) =
     Oracle.get_answer(o, q)
 
   datatype complexQuestion = Why(int) | How(string)
   datatype complexAnswer   = NoAnswer | Answer(complexQuestion, string, int)
 
-  stateful function complexOracle(question) =
+  stateful entrypoint complexOracle(question) =
     let o = Oracle.register(Contract.address, 0, FixedTTL(1000)) : oracle(complexQuestion, complexAnswer)
     let q = Oracle.query(o, question, 0, RelativeTTL(100), RelativeTTL(100))
     Oracle.respond(o, q, Answer(question, "magic", 1337))
     Oracle.get_answer(o, q)
 
-  stateful function signedComplexOracle(question, sig) =
+  stateful entrypoint signedComplexOracle(question, sig) =
     let o = Oracle.register(signature = sig, Contract.address, 0, FixedTTL(1000)) : oracle(complexQuestion, complexAnswer)
     let q = Oracle.query(o, question, 0, RelativeTTL(100), RelativeTTL(100))
     Oracle.respond(o, q, Answer(question, "magic", 1337), signature = sig)

--- a/test/contracts/remote_call.aes
+++ b/test/contracts/remote_call.aes
@@ -1,27 +1,27 @@
 
 contract Remote1 =
-  function main : (int) => int
+  entrypoint main : (int) => int
 
 contract Remote2 =
-  function call : (Remote1, int) => int
+  entrypoint call : (Remote1, int) => int
 
 contract Remote3 =
-  function get : () => int
-  function tick : () => ()
+  entrypoint get : () => int
+  entrypoint tick : () => ()
 
 contract RemoteCall =
 
-    stateful function call(r : Remote1, x : int) : int =
+    stateful entrypoint call(r : Remote1, x : int) : int =
         r.main(gas = 10000, value = 10, x)
 
-    function staged_call(r1 : Remote1, r2 : Remote2, x : int) =
+    entrypoint staged_call(r1 : Remote1, r2 : Remote2, x : int) =
         r2.call(r1, x)
 
-    function increment(r3 : Remote3) =
+    entrypoint increment(r3 : Remote3) =
         r3.tick()
 
-    function get(r3 : Remote3) =
+    entrypoint get(r3 : Remote3) =
         r3.get()
 
-    function plus(x, y) = x + y
+    entrypoint plus(x, y) = x + y
 

--- a/test/contracts/simple.aes
+++ b/test/contracts/simple.aes
@@ -1,3 +1,4 @@
 
 contract Simple =
   type t = int => int
+  entrypoint dummy() = ()

--- a/test/contracts/simple_storage.aes
+++ b/test/contracts/simple_storage.aes
@@ -6,11 +6,11 @@
    contract SimpleStorage {
        uint storedData
 
-       function set(uint x) {
+       entrypoint set(uint x) {
            storedData = x
        }
 
-       function get() constant returns (uint) {
+       entrypoint get() constant returns (uint) {
            return storedData
        }
    }
@@ -20,9 +20,9 @@ contract SimpleStorage =
 
   record state = { data : int }
 
-  function init(value : int) : state = { data = value }
+  entrypoint init(value : int) : state = { data = value }
 
-  function get() : int = state.data
+  entrypoint get() : int = state.data
 
-  stateful function set(value : int) =
+  stateful entrypoint set(value : int) =
       put(state{data = value})

--- a/test/contracts/spend_test.aes
+++ b/test/contracts/spend_test.aes
@@ -1,26 +1,26 @@
 
 contract SpendContract =
-  function withdraw : (int) => int
+  entrypoint withdraw : (int) => int
 
 contract SpendTest =
 
-  stateful function spend(to, amount) =
+  stateful entrypoint spend(to, amount) =
     let total = Contract.balance
     Chain.spend(to, amount)
     total - amount
 
-  stateful function withdraw(amount) : int =
+  stateful entrypoint withdraw(amount) : int =
     spend(Call.caller, amount)
 
-  stateful function withdraw_from(account, amount) =
+  stateful entrypoint withdraw_from(account, amount) =
     account.withdraw(amount)
     withdraw(amount)
 
-  stateful function spend_from(from, to, amount) =
+  stateful entrypoint spend_from(from, to, amount) =
     from.withdraw(amount)
     Chain.spend(to, amount)
     Chain.balance(to)
 
-  function get_balance() = Contract.balance
-  function get_balance_of(a) = Chain.balance(a)
+  entrypoint get_balance() = Contract.balance
+  entrypoint get_balance_of(a) = Chain.balance(a)
 

--- a/test/contracts/stack.aes
+++ b/test/contracts/stack.aes
@@ -6,24 +6,24 @@ contract Stack =
   record state = { stack : stack(string),
                    size  : int }
 
-  function init(ss : list(string)) = { stack = ss, size = length(ss) }
+  entrypoint init(ss : list(string)) = { stack = ss, size = length(ss) }
 
-  private function length(xs) =
+  function length(xs) =
     switch(xs)
       [] => 0
       _ :: xs => length(xs) + 1
 
-  stateful function pop() : string =
+  stateful entrypoint pop() : string =
     switch(state.stack)
       s :: ss =>
         put(state{ stack = ss, size = state.size - 1 })
         s
 
-  stateful function push(s) =
+  stateful entrypoint push(s) =
     put(state{ stack = s :: state.stack, size = state.size + 1 })
     state.size
 
-  function all() = state.stack
+  entrypoint all() = state.stack
 
-  function size() = state.size
+  entrypoint size() = state.size
 

--- a/test/contracts/state_handling.aes
+++ b/test/contracts/state_handling.aes
@@ -1,70 +1,70 @@
 contract Remote =
   record rstate = { i : int, s : string, m : map(int, int) }
 
-  function look_at : (rstate) => ()
-  function return_s : (bool) => string
-  function return_m : (bool) => map(int, int)
-  function get : (rstate) => rstate
-  function get_i : (rstate) => int
-  function get_s : (rstate) => string
-  function get_m : (rstate) => map(int, int)
+  entrypoint look_at : (rstate) => ()
+  entrypoint return_s : (bool) => string
+  entrypoint return_m : (bool) => map(int, int)
+  entrypoint get : (rstate) => rstate
+  entrypoint get_i : (rstate) => int
+  entrypoint get_s : (rstate) => string
+  entrypoint get_m : (rstate) => map(int, int)
 
-  function fun_update_i  : (rstate, int)           => rstate
-  function fun_update_s  : (rstate, string)        => rstate
-  function fun_update_m  : (rstate, map(int, int)) => rstate
-  function fun_update_mk : (rstate, int, int)      => rstate
+  entrypoint fun_update_i  : (rstate, int)           => rstate
+  entrypoint fun_update_s  : (rstate, string)        => rstate
+  entrypoint fun_update_m  : (rstate, map(int, int)) => rstate
+  entrypoint fun_update_mk : (rstate, int, int)      => rstate
 
 contract StateHandling =
 
   type state = Remote.rstate
 
-  function init(r : Remote, i : int) =
+  entrypoint init(r : Remote, i : int) =
     let state0 = { i = 0, s = "undefined", m = {} }
     r.fun_update_i(state0, i)
 
-  function read() = state
-  function read_i() = state.i
-  function read_s() = state.s
-  function read_m() = state.m
+  entrypoint read() = state
+  entrypoint read_i() = state.i
+  entrypoint read_s() = state.s
+  entrypoint read_m() = state.m
 
-  stateful function update(new_state : state) = put(new_state)
-  stateful function update_i(new_i) = put(state{ i = new_i })
-  stateful function update_s(new_s) = put(state{ s = new_s })
-  stateful function update_m(new_m) = put(state{ m = new_m })
+  stateful entrypoint update(new_state : state) = put(new_state)
+  stateful entrypoint update_i(new_i) = put(state{ i = new_i })
+  stateful entrypoint update_s(new_s) = put(state{ s = new_s })
+  stateful entrypoint update_m(new_m) = put(state{ m = new_m })
 
-  function pass_it(r : Remote) = r.look_at(state)
-  stateful function nop(r : Remote) = put(state{ i = state.i })
-  function return_it_s(r : Remote, big : bool) =
+  entrypoint pass_it(r : Remote) = r.look_at(state)
+  stateful entrypoint nop(r : Remote) = put(state{ i = state.i })
+  entrypoint return_it_s(r : Remote, big : bool) =
     let x = r.return_s(big)
     String.length(x)
-  function return_it_m(r : Remote, big : bool) =
+  entrypoint return_it_m(r : Remote, big : bool) =
     let x = r.return_m(big)
     Map.size(x)
 
-  function pass(r : Remote) = r.get(state)
-  function pass_i(r : Remote) = r.get_i(state)
-  function pass_s(r : Remote) = r.get_s(state)
-  function pass_m(r : Remote) = r.get_m(state)
+  entrypoint pass(r : Remote) = r.get(state)
+  entrypoint pass_i(r : Remote) = r.get_i(state)
+  entrypoint pass_s(r : Remote) = r.get_s(state)
+  entrypoint pass_m(r : Remote) = r.get_m(state)
 
-  function pass_update_i(r : Remote, i) = r.fun_update_i(state, i)
-  function pass_update_s(r : Remote, s) = r.fun_update_s(state, s)
-  function pass_update_m(r : Remote, m) = r.fun_update_m(state, m)
+  entrypoint pass_update_i(r : Remote, i) = r.fun_update_i(state, i)
+  entrypoint pass_update_s(r : Remote, s) = r.fun_update_s(state, s)
+  entrypoint pass_update_m(r : Remote, m) = r.fun_update_m(state, m)
 
-  stateful function remote_update_i (r : Remote, i)    = put(r.fun_update_i(state, i))
-  stateful function remote_update_s (r : Remote, s)    = put(r.fun_update_s(state, s))
-  stateful function remote_update_m (r : Remote, m)    = put(r.fun_update_m(state, m))
-  stateful function remote_update_mk(r : Remote, k, v) = put(r.fun_update_mk(state, k, v))
+  stateful entrypoint remote_update_i (r : Remote, i)    = put(r.fun_update_i(state, i))
+  stateful entrypoint remote_update_s (r : Remote, s)    = put(r.fun_update_s(state, s))
+  stateful entrypoint remote_update_m (r : Remote, m)    = put(r.fun_update_m(state, m))
+  stateful entrypoint remote_update_mk(r : Remote, k, v) = put(r.fun_update_mk(state, k, v))
 
   // remote called
-  function look_at(s : state) = ()
+  entrypoint look_at(s : state) = ()
 
-  function get(s : state) = s
-  function get_i(s : state) = s.i
-  function get_s(s : state) = s.s
-  function get_m(s : state) = s.m
+  entrypoint get(s : state) = s
+  entrypoint get_i(s : state) = s.i
+  entrypoint get_s(s : state) = s.s
+  entrypoint get_m(s : state) = s.m
 
-  function fun_update_i(st, ni) = st{ i = ni }
-  function fun_update_s(st, ns) = st{ s = ns }
-  function fun_update_m(st, nm) = st{ m = nm }
-  function fun_update_mk(st, k, v) = st{ m = st.m{[k] = v} }
+  entrypoint fun_update_i(st, ni) = st{ i = ni }
+  entrypoint fun_update_s(st, ns) = st{ s = ns }
+  entrypoint fun_update_m(st, nm) = st{ m = nm }
+  entrypoint fun_update_mk(st, k, v) = st{ m = st.m{[k] = v} }
 

--- a/test/contracts/stateful.aes
+++ b/test/contracts/stateful.aes
@@ -1,18 +1,18 @@
 
 contract Remote =
-  stateful function remote_spend : (address, int) => ()
-  function remote_pure : int => int
+  stateful entrypoint remote_spend : (address, int) => ()
+  entrypoint remote_pure : int => int
 
 contract Stateful =
 
-  private function pure(x) = x + 1
-  private stateful function local_spend(a) =
+  function pure(x) = x + 1
+  stateful function local_spend(a) =
     Chain.spend(a, 1000)
 
   // Non-stateful functions cannot mention stateful functions
-  function fail1(a : address) = Chain.spend(a, 1000)
-  function fail2(a : address) = local_spend(a)
-  function fail3(a : address) =
+  entrypoint fail1(a : address) = Chain.spend(a, 1000)
+  entrypoint fail2(a : address) = local_spend(a)
+  entrypoint fail3(a : address) =
     let foo = Chain.spend
     foo(a, 1000)
 
@@ -20,35 +20,35 @@ contract Stateful =
   private function fail4(a) = Chain.spend(a, 1000)
 
   // If annotated, stateful functions are allowed
-  stateful function ok1(a : address) = Chain.spend(a, 1000)
+  stateful entrypoint ok1(a : address) = Chain.spend(a, 1000)
 
   // And pure functions are always allowed
-  stateful function ok2(a : address) = pure(5)
-  stateful function ok3(a : address) =
+  stateful entrypoint ok2(a : address) = pure(5)
+  stateful entrypoint ok3(a : address) =
     let foo = pure
     foo(5)
 
   // No error here (fail4 is annotated as not stateful)
-  function ok4(a : address) = fail4(a)
+  entrypoint ok4(a : address) = fail4(a)
 
   // Lamdbas are checked at the construction site
-  private function fail5() : address => () = (a) => Chain.spend(a, 1000)
+  function fail5() : address => () = (a) => Chain.spend(a, 1000)
 
   // .. so you can pass a stateful lambda to a non-stateful higher-order
   // function:
-  private function apply(f : 'a => 'b, x) = f(x)
-  stateful function ok5(a : address) =
+  function apply(f : 'a => 'b, x) = f(x)
+  stateful entrypoint ok5(a : address) =
     apply((val) => Chain.spend(a, val), 1000)
 
   // It doesn't matter if remote calls are stateful or not
-  function ok6(r : Remote) = r.remote_spend(Contract.address, 1000)
-  function ok7(r : Remote) = r.remote_pure(5)
+  entrypoint ok6(r : Remote) = r.remote_spend(Contract.address, 1000)
+  entrypoint ok7(r : Remote) = r.remote_pure(5)
 
   // But you can't send any tokens if not stateful
-  function fail6(r : Remote) = r.remote_spend(value = 1000, Contract.address, 1000)
-  function fail7(r : Remote) = r.remote_pure(value = 1000, 5)
-  function fail8(r : Remote) =
+  entrypoint fail6(r : Remote) = r.remote_spend(value = 1000, Contract.address, 1000)
+  entrypoint fail7(r : Remote) = r.remote_pure(value = 1000, 5)
+  entrypoint fail8(r : Remote) =
     let foo = r.remote_pure
     foo(value = 1000, 5)
-  function ok8(r : Remote) = r.remote_spend(Contract.address, 1000, value = 0)
+  entrypoint ok8(r : Remote) = r.remote_spend(Contract.address, 1000, value = 0)
 

--- a/test/contracts/strings.aes
+++ b/test/contracts/strings.aes
@@ -1,4 +1,4 @@
 contract Strings =
-    function str_len(s) = String.length(s)
-    function str_concat(s1, s2) = String.concat(s1, s2)
+    entrypoint str_len(s) = String.length(s)
+    entrypoint str_concat(s1, s2) = String.concat(s1, s2)
 

--- a/test/contracts/test.aes
+++ b/test/contracts/test.aes
@@ -91,10 +91,10 @@ contract Identity =
   // }
   // let id(x) = x
   // let main(xs) = map(double,xs)
-  function z(f,x) = x
-  private function s(n) = (f,x)=>f(n(f,x))
-  private function add(m,n) = (f,x)=>m(f,n(f,x))
-  function main(_) =
+  entrypoint z(f,x) = x
+  function s(n) = (f,x)=>f(n(f,x))
+  function add(m,n) = (f,x)=>m(f,n(f,x))
+  entrypoint main(_) =
     let three=s(s(s(z)))
     add(three,three)
        (((i)=>i+1),0)

--- a/test/contracts/type_clash.aes
+++ b/test/contracts/type_clash.aes
@@ -2,12 +2,12 @@
 contract Remote =
 
   type themap = map(int, string)
-  function foo : () => themap
+  entrypoint foo : () => themap
 
 contract Main =
 
   type themap = map(string, int)
 
   // Should fail
-  function foo(r : Remote) : themap = r.foo()
+  entrypoint foo(r : Remote) : themap = r.foo()
 

--- a/test/contracts/type_errors.aes
+++ b/test/contracts/type_errors.aes
@@ -6,54 +6,54 @@ contract Test =
   record r2 = { z : int, w : int }
   record r3 = { x : int, z : int }
 
-  function set_x(r : r, z) = r{ x["foo"] @ x = x + 1 }
+  entrypoint set_x(r : r, z) = r{ x["foo"] @ x = x + 1 }
 
-  function bla(m : map(string, int)) = { [0] = "bla", ["foo"] = "" }
+  entrypoint bla(m : map(string, int)) = { [0] = "bla", ["foo"] = "" }
 
-  function foo(r) = r { y = 0 }
-  function bar() = { y = "foo", z = 0 }
-  function baz() = { y = "foo", w = 0 }
+  entrypoint foo(r) = r { y = 0 }
+  entrypoint bar() = { y = "foo", z = 0 }
+  entrypoint baz() = { y = "foo", w = 0 }
 
-  function foo1() = zz
+  entrypoint foo1() = zz
 
-  function test1() : string = { y = 0 }
-  function test2(x : string) = x { y = 0 }
-  function test3(x : string) = x { y @ y = y + 1 }
-  function test4(x : string) : int = x.y
+  entrypoint test1() : string = { y = 0 }
+  entrypoint test2(x : string) = x { y = 0 }
+  entrypoint test3(x : string) = x { y @ y = y + 1 }
+  entrypoint test4(x : string) : int = x.y
 
-  function test5(xs) =
+  entrypoint test5(xs) =
     switch(xs)
       x :: x => x
       [] => 0
 
-  function case_pat(xs) =
+  entrypoint case_pat(xs) =
     switch(xs)
       [] => 0
       x :: xs => "x"
 
-  function foo2(m : map(string, int)) = m{ [1] = "bla" }
+  entrypoint foo2(m : map(string, int)) = m{ [1] = "bla" }
 
-  function bad_if(x, y : int, w : int, z : string) =
+  entrypoint bad_if(x, y : int, w : int, z : string) =
     if(x) y
     elif(x) w
     else z
 
-  function type_error(r, x) =
+  entrypoint type_error(r, x) =
     set_x(set_x(x, r), x)
 
-  function repeated_arg(x : int, y, x : string, y : bool) : string = x
+  entrypoint repeated_arg(x : int, y, x : string, y : bool) : string = x
 
-  function missing1() =
+  entrypoint missing1() =
     let x = 0
 
-  function missing_fun1() =
+  entrypoint missing_fun1() =
     let f(x) = x
 
-  function missing2() =
+  entrypoint missing2() =
     let x = 0
     let y = 0
 
-  function missing_fun2() =
+  entrypoint missing_fun2() =
     let f() = 0
     let g() = f()
 

--- a/test/contracts/variant_types.aes
+++ b/test/contracts/variant_types.aes
@@ -7,21 +7,21 @@ contract VariantTypes =
 
   datatype color = Red | Green | Blue | Grey(int)
 
-  function init() = Stopped
+  entrypoint init() = Stopped
 
-  stateful function start(bal : int) =
+  stateful entrypoint start(bal : int) =
     switch(state)
       Stopped => put(Started({owner = Call.caller, balance = bal, color = Grey(0)}))
 
-  stateful function stop() =
+  stateful entrypoint stop() =
     switch(state)
       Started(st) =>
         require(Call.caller == st.owner, "required")
         put(Stopped)
         st.balance
 
-  function get_color()  = switch(state) Started(st) => st.color
-  stateful function set_color(c) = switch(state) Started(st) => put(Started(st{color = c}))
+  entrypoint get_color()  = switch(state) Started(st) => st.color
+  stateful entrypoint set_color(c) = switch(state) Started(st) => put(Started(st{color = c}))
 
-  function get_state() = state
+  entrypoint get_state() = state
 


### PR DESCRIPTION
Now functions exported from a contract must be defined using `entrypoint` instead of `function`. Normal functions are always private. This is to make it harder to accidentally export a private function from a contract. Example:

```
contract Example =
  entrypoint inc(x) = add(x, 1)   // exported
  function add(x, y) = x + y      // private
```