### PR TITLE
Fix split_pat

### DIFF
--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -681,7 +681,7 @@ split_pat({con, As, I, Pats}) ->
     Xs = [fresh_name() || _ <- Pats],
     {{con, As, I, Xs}, Pats};
 split_pat({tuple, Pats}) ->
-    Xs = [fresh_name() || _ <- Pats],
+    Xs = [{var, fresh_name()} || _ <- Pats],
     {{tuple, Xs}, Pats}.
 
 -spec split_vars(fsplit_pat(), ftype()) -> [{var_name(), ftype()}].


### PR DESCRIPTION
Due to bad `fsplit_pat` construction the following contract
```
contract XD =

   entrypoint tuplify3() = (t) => switch(t)
     (x, y, z) => 3
```
used not to compile