### PR TITLE
Changed 'require' function return type to Unit

### DIFF
--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -385,7 +385,7 @@ global_env() ->
                      {"FixedTTL",    Fun1(Int, TTL)},
                      %% Abort
                      {"abort", Fun1(String, A)},
-                     {"require", Fun([Bool, String], A)}])
+                     {"require", Fun([Bool, String], Unit)}])
         , types = MkDefs(
                     [{"int", 0}, {"bool", 0}, {"char", 0}, {"string", 0}, {"address", 0},
                      {"hash", {[], {alias_t, Bytes(32)}}},


### PR DESCRIPTION
`require` function could be used to exploit type system, because it was returning `'a` type instead of `()`:

bug copyright (c) Martin Grigorov
```
contract Identity =
  type state = ()
  entrypoint main(x : int) = x
  
  entrypoint sum(a: int, b: int) = a + b
  
  entrypoint test_sum_correct() =
        let result = 5
        require(sum(2,3)== 5, "Result of sum is incorrect!")
```
