### PR TITLE
Covered qid case in ast_typerep

### DIFF
--- a/src/aeso_ast_to_icode.erl
+++ b/src/aeso_ast_to_icode.erl
@@ -728,7 +728,7 @@ ast_typerep({con, _, _}, _) ->
     word;   %% Contract type
 ast_typerep({bytes_t, _, Len}, _) ->
     bytes_t(Len);
-ast_typerep({app_t, _, {id, _, Name}, Args}, Icode) ->
+ast_typerep({app_t, _, {I, _, Name}, Args}, Icode) when I =:= id; I =:= qid ->
     ArgReps = [ ast_typerep(Arg, Icode) || Arg <- Args ],
     lookup_type_id(Name, ArgReps, Icode);
 ast_typerep({tvar,_,A}, #{ type_vars := TypeVars }) ->


### PR DESCRIPTION
Because `qid` was not accepted as a typefunction the following code 

```
contract Test = 
   datatype myOption('a) = MyNone | MySome('a)
   entrypoint optionFn(v: myOption(string)): myOption(string) = v
```
Used to lead to `function_clause` error.

Bug copyright (c) @nduchak