### PR TITLE
PT-167701356 split store

### DIFF
--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -156,7 +156,7 @@ bind_tvars(Xs, Env) ->
 check_tvar(#env{ typevars = TVars}, T = {tvar, _, X}) ->
     case TVars == unrestricted orelse lists:member(X, TVars) of
         true  -> ok;
-        false -> type_error({unbound_type_variable, T})
+        false -> type_error({unbound_type, T})
     end,
     T.
 
@@ -2160,6 +2160,8 @@ pp_error({contract_has_no_entrypoints, Con}) ->
     io_lib:format("The contract ~s (at ~s) has no entrypoints. Since Sophia version 3.2, public\n"
                   "contract functions must be declared with the 'entrypoint' keyword instead of\n"
                   "'function'.\n", [pp_expr("", Con), pp_loc(Con)]);
+pp_error({unbound_type, Type}) ->
+    io_lib:format("Unbound type ~s (at ~s).\n", [pp_type("", Type), pp_loc(Type)]);
 pp_error(Err) ->
     io_lib:format("Unknown error: ~p\n", [Err]).
 

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -239,7 +239,8 @@ to_fcode(Env, [{contract, _, {con, _, Main}, Decls}]) ->
     #{ contract_name => Main,
        state_type    => StateType,
        event_type    => EventType,
-       functions     => add_event_function(Env1, EventType, Funs) };
+       functions     => add_init_function(Env1,
+                        add_event_function(Env1, EventType, Funs)) };
 to_fcode(Env, [{contract, _, {con, _, Con}, Decls} | Code]) ->
     Env1 = decls_to_fcode(Env#{ context => {abstract_contract, Con} }, Decls),
     to_fcode(Env1, Code);
@@ -819,6 +820,19 @@ builtin_to_fcode(Builtin, Args) ->
         false -> {builtin, Builtin, Args}
     end.
 
+%% -- Init function --
+
+add_init_function(_Env, Funs) ->
+    InitName = {entrypoint, <<"init">>},
+    InitFun = #{ args := InitArgs } =
+        case maps:get(InitName, Funs, none) of
+            none -> #{ attrs => [], args => [], return => {tuple, []}, body => {tuple, []} };
+            Info -> Info
+        end,
+    Vars = [ {var, X} || {X, _} <- InitArgs ],
+    Funs#{ init => InitFun#{ return => {tuple, []},
+                             body   => {builtin, set_state, [{def, InitName, Vars}]} } }.
+
 %% -- Event function --
 
 add_event_function(_Env, none, Funs) -> Funs;
@@ -1009,8 +1023,7 @@ make_fun_name(#{ context := Context }, Ann, Name) ->
     Entrypoint = proplists:get_value(entrypoint, Ann, false),
     case Context of
         {main_contract, Main} ->
-            if Name == "init" -> init;
-               Entrypoint     -> {entrypoint, list_to_binary(Name)};
+            if Entrypoint     -> {entrypoint, list_to_binary(Name)};
                true           -> {local_fun, [Main, Name]}
             end;
         {namespace, Lib} ->
@@ -1288,7 +1301,7 @@ pp_fun(Name, #{ args := Args, return := Return, body := Body }) ->
                pp_text(" : "), pp_ftype(Return), pp_text(" =")]),
              prettypr:nest(2, pp_fexpr(Body))).
 
-pp_fun_name(init)            -> pp_text(init);
+pp_fun_name(init)            -> pp_text('INIT');
 pp_fun_name(event)           -> pp_text(event);
 pp_fun_name({entrypoint, E}) -> pp_text(binary_to_list(E));
 pp_fun_name({local_fun, Q})  -> pp_text(string:join(Q, ".")).

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -139,7 +139,7 @@ compile(FCode, Options) ->
 make_function_id(X) ->
     aeb_fate_code:symbol_identifier(make_function_name(X)).
 
-make_function_name(init)               -> <<"init">>;
+make_function_name(init)               -> <<"INIT">>;
 make_function_name(event)              -> <<"Chain.event">>;
 make_function_name({entrypoint, Name}) -> Name;
 make_function_name({local_fun, Xs})    -> list_to_binary("." ++ string:join(Xs, ".")).
@@ -196,7 +196,7 @@ add_default_init_function(SFuns, StateType) when StateType /= {tuple, []} ->
     SFuns;
 add_default_init_function(SFuns, {tuple, []}) ->
     %% Only add default if the init function is not present
-    InitName = make_function_name(init),
+    InitName = make_function_name({entrypoint, <<"init">>}),
     case maps:find(InitName, SFuns) of
         {ok, _} ->
             SFuns;


### PR DESCRIPTION
[PT-167701356](https://www.pivotaltracker.com/story/show/167701356)

Change compilation of the `init` function in FATE. Now generates a new function `INIT` that writes the state instead of returning it. The create contract transaction calls this function instead of `init` (unbeknownst to the user; the calldata still has `init`). See aeternity/aeternity#2619 for this.

The reason for this is to allow the compiler to decide the layout of the store. Currently it writes the entire state to state register 0, but in the future it can split up the state over multiple registers without requiring any changes to the VM.