### PR TITLE
Don't generate remote tail calls

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 
-{deps, [ {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref,"2a9035d"}}}
+{deps, [ {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref,"af6224c"}}}
        , {getopt, "1.0.1"}
        , {eblake2, "1.0.0"}
        , {jsx, {git, "https://github.com/talentdeficit/jsx.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-       {ref,"2a9035d5ef72bc65e51e4b9a1a958bb8ba2c6747"}},
+       {ref,"af6224cb3b3732562df58485b2bd2a0534d74f2a"}},
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",


### PR DESCRIPTION
Minor change to reflect aeternity/aebytecode#66, which removes remote tail calls and adds an arity argument to normal remote calls.