### PR TITLE
Bytes.concat and Bytes.split

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 
-{deps, [ {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref,"3106ca1"}}}
+{deps, [ {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref,"17c9656"}}}
        , {getopt, "1.0.1"}
        , {eblake2, "1.0.0"}
        , {jsx, {git, "https://github.com/talentdeficit/jsx.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-       {ref,"3106ca13063cf12f23e459cf60c6f987777a7e83"}},
+       {ref,"17c9656f5ca60f6522d598aaf2999660030f8664"}},
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -899,7 +899,6 @@ infer_nonrec(Env, LetFun) ->
     create_constraints(),
     NewLetFun = infer_letfun(Env, LetFun),
     check_special_funs(Env, NewLetFun),
-    solve_constraints(Env),
     destroy_and_report_unsolved_constraints(Env),
     Result = {TypeSig, _} = instantiate(NewLetFun),
     print_typesig(TypeSig),
@@ -1491,12 +1490,10 @@ create_constraints() ->
     create_bytes_constraints(),
     create_field_constraints().
 
-solve_constraints(Env) ->
+destroy_and_report_unsolved_constraints(Env) ->
     solve_named_argument_constraints(Env),
     solve_bytes_constraints(Env),
-    solve_field_constraints(Env).
-
-destroy_and_report_unsolved_constraints(Env) ->
+    solve_field_constraints(Env),
     destroy_and_report_unsolved_field_constraints(Env),
     destroy_and_report_unsolved_bytes_constraints(Env),
     destroy_and_report_unsolved_named_argument_constraints(Env).

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -1135,7 +1135,7 @@ infer_expr(Env, {list_comp, AsLC, Yield, [{letval, AsLV, Pattern, Type, E}|Rest]
     };
 infer_expr(Env, {list_comp, AsLC, Yield, [Def={letfun, AsLF, _, _, _, _}|Rest]}) ->
     {{Name, TypeSig}, LetFun} = infer_letfun(Env, Def),
-    FunT = freshen_type(AsLF, typesig_to_fun_t(TypeSig)),
+    FunT = typesig_to_fun_t(TypeSig),
     NewE = bind_var({id, AsLF, Name}, FunT, Env),
     {typed, _, {list_comp, _, TypedYield, TypedRest}, ResType} =
         infer_expr(NewE, {list_comp, AsLC, Yield, Rest}),

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -83,7 +83,7 @@
 -type qname() :: [string()].
 -type typesig() :: {type_sig, aeso_syntax:ann(), type_constraints(), [aeso_syntax:named_arg_t()], [type()], type()}.
 
--type type_constraints() :: none.
+-type type_constraints() :: none | bytes_concat | bytes_split.
 
 -type fun_info()  :: {aeso_syntax:ann(), typesig() | type()}.
 -type type_info() :: {aeso_syntax:ann(), typedef()}.

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -198,7 +198,7 @@ builtins() ->
               {["String"],   [{"length", 1}, {"concat", 2}, {"sha3", 1}, {"sha256", 1}, {"blake2b", 1}]},
               {["Bits"],     [{"set", 2}, {"clear", 2}, {"test", 2}, {"sum", 1}, {"intersection", 2},
                               {"union", 2}, {"difference", 2}, {"none", none}, {"all", none}]},
-              {["Bytes"],    [{"to_int", 1}, {"to_str", 1}]},
+              {["Bytes"],    [{"to_int", 1}, {"to_str", 1}, {"concat", 2}, {"split", 1}]},
               {["Int"],      [{"to_str", 1}]},
               {["Address"],  [{"to_str", 1}, {"is_oracle", 1}, {"is_contract", 1}, {"is_payable", 1}]}
              ],
@@ -427,6 +427,9 @@ expr_to_fcode(Env, Type, {qid, Ann, X}) ->
             validate_aens_resolve_type(Ann, ResType, AensType),
             TypeArgs = [{lit, {typerep, AensType}}],
             {builtin_u, B, Ar, TypeArgs};
+        {builtin_u, B = bytes_split, Ar} ->
+            {fun_t, _, _, _, {tuple_t, _, [{bytes_t, _, N}, _]}} = Type,
+            {builtin_u, B, Ar, [{lit, {int, N}}]};
         Other -> Other
     end;
 

--- a/src/aeso_ast_to_icode.erl
+++ b/src/aeso_ast_to_icode.erl
@@ -496,6 +496,8 @@ is_builtin_fun({qid, _, ["Address", "is_contract"]}, _Icode)                 -> 
 is_builtin_fun({qid, _, ["Address", "is_payable"]}, _Icode)                  -> true;
 is_builtin_fun({qid, _, ["Bytes", "to_int"]}, _Icode)                        -> true;
 is_builtin_fun({qid, _, ["Bytes", "to_str"]}, _Icode)                        -> true;
+is_builtin_fun({qid, _, ["Bytes", "concat"]}, _Icode)                        -> true;
+is_builtin_fun({qid, _, ["Bytes", "split"]}, _Icode)                         -> true;
 is_builtin_fun(_, _)                                                         -> false.
 
 %% -- Code generation for builtin functions --
@@ -718,6 +720,13 @@ builtin_code(_, {qid, _, ["Bytes", "to_int"]}, [Bytes], _, _, Icode) ->
 builtin_code(_, {qid, _, ["Bytes", "to_str"]}, [Bytes], _, _, Icode) ->
     {typed, _, _, {bytes_t, _, N}} = Bytes,
     builtin_call({bytes_to_str, N}, [ast_body(Bytes, Icode)]);
+builtin_code(_, {qid, _, ["Bytes", "concat"]}, [A, B], [TypeA, TypeB], _, Icode) ->
+    {bytes_t, _, M} = TypeA,
+    {bytes_t, _, N} = TypeB,
+    builtin_call({bytes_concat, M, N}, [ast_body(A, Icode), ast_body(B, Icode)]);
+builtin_code(_, {qid, _, ["Bytes", "split"]}, [A], _, ResType, Icode) ->
+    {tuple_t, _, [{bytes_t, _, M}, {bytes_t, _, N}]} = ResType,
+    builtin_call({bytes_split, M, N}, [ast_body(A, Icode)]);
 builtin_code(_As, Fun, _Args, _ArgsT, _RetT, _Icode) ->
     gen_error({missing_code_for, Fun}).
 

--- a/src/aeso_errors.erl
+++ b/src/aeso_errors.erl
@@ -59,7 +59,8 @@ pos(File, Line, Col) ->
 -spec throw(_) -> ok | no_return().
 throw([]) -> ok;
 throw(Errs) when is_list(Errs) ->
-    erlang:throw({error, Errs});
+    SortedErrs = lists:sort(fun(E1, E2) -> E1#err.pos =< E2#err.pos end, Errs),
+    erlang:throw({error, SortedErrs});
 throw(#err{} = Err) ->
     erlang:throw({error, [Err]}).
 

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -106,6 +106,8 @@
      Op =:= 'AUTH_TX_HASH'         orelse
      Op =:= 'BYTES_TO_INT'         orelse
      Op =:= 'BYTES_TO_STR'         orelse
+     Op =:= 'BYTES_CONCAT'         orelse
+     Op =:= 'BYTES_SPLIT'          orelse
      Op =:= 'ORACLE_CHECK'         orelse
      Op =:= 'ORACLE_CHECK_QUERY'   orelse
      Op =:= 'IS_ORACLE'            orelse
@@ -490,6 +492,10 @@ builtin_to_scode(Env, bytes_to_int, [_] = Args) ->
     call_to_scode(Env, aeb_fate_ops:bytes_to_int(?a, ?a), Args);
 builtin_to_scode(Env, bytes_to_str, [_] = Args) ->
     call_to_scode(Env, aeb_fate_ops:bytes_to_str(?a, ?a), Args);
+builtin_to_scode(Env, bytes_concat, [_, _] = Args) ->
+    call_to_scode(Env, aeb_fate_ops:bytes_concat(?a, ?a, ?a), Args);
+builtin_to_scode(Env, bytes_split, [_, _] = Args) ->
+    call_to_scode(Env, aeb_fate_ops:bytes_split(?a, ?a, ?a), Args);
 builtin_to_scode(Env, abort, [_] = Args) ->
     call_to_scode(Env, aeb_fate_ops:abort(?a), Args);
 builtin_to_scode(Env, chain_spend, [_, _] = Args) ->
@@ -846,6 +852,8 @@ attributes(I) ->
         {'AUTH_TX_HASH', A}                   -> Pure(A, []);
         {'BYTES_TO_INT', A, B}                -> Pure(A, [B]);
         {'BYTES_TO_STR', A, B}                -> Pure(A, [B]);
+        {'BYTES_CONCAT', A, B, C}             -> Pure(A, [B, C]);
+        {'BYTES_SPLIT', A, B, C}              -> Pure(A, [B, C]);
         {'ORACLE_CHECK', A, B, C, D}          -> Impure(A, [B, C, D]);
         {'ORACLE_CHECK_QUERY', A, B, C, D, E} -> Impure(A, [B, C, D, E]);
         {'IS_ORACLE', A, B}                   -> Impure(A, [B]);

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -511,6 +511,50 @@ failing_contracts() ->
         [<<?Pos(3, 5)
            "Unbound variable Chain.event at line 3, column 5\n"
            "Did you forget to define the event type?">>])
+    , ?TYPE_ERROR(bad_bytes_concat,
+        [<<?Pos(12, 40)
+           "Failed to resolve byte array lengths in call to Bytes.concat with arguments of type\n"
+           "  - 'g  (at line 12, column 20)\n"
+           "  - 'h  (at line 12, column 23)\n"
+           "and result type\n"
+           "  - bytes(10)  (at line 12, column 28)">>,
+         <<?Pos(13, 28)
+           "Failed to resolve byte array lengths in call to Bytes.concat with arguments of type\n"
+           "  - 'd  (at line 13, column 20)\n"
+           "  - 'e  (at line 13, column 23)\n"
+           "and result type\n"
+           "  - 'f  (at line 13, column 14)">>,
+         <<?Pos(15, 5)
+           "Cannot unify bytes(26)\n"
+           "         and bytes(25)\n"
+           "at line 15, column 5">>,
+         <<?Pos(17, 5)
+           "Failed to resolve byte array lengths in call to Bytes.concat with arguments of type\n"
+           "  - bytes(6)  (at line 16, column 24)\n"
+           "  - 'b  (at line 16, column 34)\n"
+           "and result type\n"
+           "  - 'c  (at line 16, column 39)">>,
+         <<?Pos(19, 25)
+           "Cannot resolve length of byte array.">>])
+    , ?TYPE_ERROR(bad_bytes_split,
+         [<<?Pos(13, 5)
+            "Failed to resolve byte array lengths in call to Bytes.split with argument of type\n"
+            "  - 'f  (at line 12, column 20)\n"
+            "and result types\n"
+            "  - 'e  (at line 13, column 5)\n"
+            "  - bytes(20)  (at line 12, column 29)">>,
+          <<?Pos(16, 5)
+            "Failed to resolve byte array lengths in call to Bytes.split with argument of type\n"
+            "  - bytes(15)  (at line 15, column 24)\n"
+            "and result types\n"
+            "  - 'c  (at line 16, column 5)\n"
+            "  - 'd  (at line 16, column 5)">>,
+          <<?Pos(19, 5)
+            "Failed to resolve byte array lengths in call to Bytes.split with argument of type\n"
+            "  - 'b  (at line 18, column 20)\n"
+            "and result types\n"
+            "  - bytes(20)  (at line 18, column 25)\n"
+            "  - 'a  (at line 19, column 5)">>])
     ].
 
 -define(Path(File), "code_errors/" ??File).

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -143,6 +143,7 @@ compilable_contracts() ->
      "address_chain",
      "namespace_bug",
      "bytes_to_x",
+     "bytes_concat",
      "aens",
      "tuple_match",
      "cyclic_include",

--- a/test/contracts/bad_bytes_concat.aes
+++ b/test/contracts/bad_bytes_concat.aes
@@ -1,0 +1,19 @@
+contract BytesConcat =
+
+  entrypoint test1(x : bytes(10), y : bytes(20)) =
+    Bytes.concat(x, y)
+
+  entrypoint test2(x : bytes(10), y) : bytes(15) =
+    Bytes.concat(x, y)
+
+  entrypoint test3(x, y : bytes(20)) : bytes(25) =
+    Bytes.concat(x, y)
+
+  entrypoint fail1(x, y) : bytes(10) = Bytes.concat(x, y)
+  entrypoint fail2(x, y) = Bytes.concat(x, y)
+  entrypoint fail3(x : bytes(6), y : bytes(20)) : bytes(25) =
+    Bytes.concat(x, y)
+  entrypoint fail4(x : bytes(6), y) : _ =
+    Bytes.concat(x, y)
+
+  entrypoint fail5(x) = Bytes.to_str(x)

--- a/test/contracts/bad_bytes_split.aes
+++ b/test/contracts/bad_bytes_split.aes
@@ -1,0 +1,20 @@
+contract BytesSplit =
+
+  entrypoint test1(x) : bytes(10) * bytes(20) =
+    Bytes.split(x)
+
+  entrypoint test2(x : bytes(15)) : bytes(10) * _ =
+    Bytes.split(x)
+
+  entrypoint test3(x : bytes(25)) : _ * bytes(20) =
+    Bytes.split(x)
+
+  entrypoint fail1(x) : _ * bytes(20) =
+    Bytes.split(x)
+
+  entrypoint fail2(x : bytes(15)) : _ =
+    Bytes.split(x)
+
+  entrypoint fail3(x) : bytes(20) * _ =
+    Bytes.split(x)
+

--- a/test/contracts/bytes_concat.aes
+++ b/test/contracts/bytes_concat.aes
@@ -1,0 +1,4 @@
+contract BytesConcat =
+  entrypoint rot(a : bytes(3)) =
+    switch (Bytes.split(a))
+      (b, c) => Bytes.concat(c : bytes(2), b)


### PR DESCRIPTION
- Pivotal: [PT-168370742](https://www.pivotaltracker.com/story/show/168370742)
- aeternity/aebytecode#80
- aeternity/aeternity#2762

Adds
```
  Bytes.concat : (bytes(A), bytes(B)) => bytes(A + B)
  Bytes.split : bytes(A + B) => bytes(A) * bytes(B)
```
The type checker will solve for `A` and `B` and give an error message if they don't solve to concrete natural numbers.