### PR TITLE
Allow underscore separators in number and bytes literals

### DIFF
--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -152,7 +152,8 @@ compilable_contracts() ->
      "manual_stdlib_include",
      "list_comp",
      "payable",
-     "unapplied_builtins"
+     "unapplied_builtins",
+     "underscore_number_literals"
     ].
 
 not_yet_compilable(fate) -> [];

--- a/test/contracts/underscore_number_literals.aes
+++ b/test/contracts/underscore_number_literals.aes
@@ -1,0 +1,13 @@
+
+contract UnderscoreNumberLiterals =
+
+  entrypoint ints() : list(int) =
+    [ 1_999_000_000,
+      19_99_00_00_00,
+      0xfff_FFF_010 ]
+
+  entrypoint bytes() : list(bytes(4)) =
+    [ #abcd_ef_00,
+      #01_02_03_04,
+      #aaaa_FFFF ]
+


### PR DESCRIPTION
For instance, `1_000_000_000` or `#FFFF_FFFF_FFFF_FFFF`