### PR TITLE
GH-194 let patterns

### DIFF
--- a/src/aeso_parser.erl
+++ b/src/aeso_parser.erl
@@ -164,9 +164,7 @@ letdecl() ->
 letdef() -> choice(valdef(), fundef()).
 
 valdef() ->
-    choice(
-        ?RULE(id(),                   tok('='), body(), {letval, [], _1, type_wildcard(), _3}),
-        ?RULE(id(), tok(':'), type(), tok('='), body(), {letval, [], _1, _3, _5})).
+    ?RULE(pattern(), tok('='), body(), {letval, [], _1, _3}).
 
 fundef() ->
     choice(
@@ -238,7 +236,7 @@ branch() ->
     ?RULE(pattern(), keyword('=>'), body(), {'case', _2, _1, _3}).
 
 pattern() ->
-    ?LET_P(E, expr500(), parse_pattern(E)).
+    ?LET_P(E, expr(), parse_pattern(E)).
 
 %% -- Expressions ------------------------------------------------------------
 
@@ -297,7 +295,7 @@ comprehension_if() ->
     ?RULE(keyword('if'), parens(expr()), {comprehension_if, _1, _2}).
 
 comprehension_bind() ->
-    ?RULE(id(), tok('<-'), expr(), {comprehension_bind, _1, _3}).
+    ?RULE(pattern(), tok('<-'), expr(), {comprehension_bind, _1, _3}).
 
 arg_expr() ->
     ?LAZY_P(
@@ -553,6 +551,8 @@ parse_pattern({list, Ann, Es}) ->
     {list, Ann, lists:map(fun parse_pattern/1, Es)};
 parse_pattern({record, Ann, Fs}) ->
     {record, Ann, lists:map(fun parse_field_pattern/1, Fs)};
+parse_pattern({typed, Ann, E, Type}) ->
+    {typed, Ann, parse_pattern(E), Type};
 parse_pattern(E = {con, _, _})    -> E;
 parse_pattern(E = {qcon, _, _})   -> E;
 parse_pattern(E = {id, _, _})     -> E;

--- a/src/aeso_parser.erl
+++ b/src/aeso_parser.erl
@@ -543,6 +543,8 @@ list_comp_e(Ann, Expr, Binds) -> {list_comp, Ann, Expr, Binds}.
 -spec parse_pattern(aeso_syntax:expr()) -> aeso_parse_lib:parser(aeso_syntax:pat()).
 parse_pattern({app, Ann, Con = {'::', _}, Es}) ->
     {app, Ann, Con, lists:map(fun parse_pattern/1, Es)};
+parse_pattern({app, Ann, {'-', _}, [{int, _, N}]}) ->
+    {int, Ann, -N};
 parse_pattern({app, Ann, Con = {Tag, _, _}, Es}) when Tag == con; Tag == qcon ->
     {app, Ann, Con, lists:map(fun parse_pattern/1, Es)};
 parse_pattern({tuple, Ann, Es}) ->

--- a/src/aeso_pretty.erl
+++ b/src/aeso_pretty.erl
@@ -169,7 +169,7 @@ decl(D = {letfun, Attrs, _, _, _, _}) ->
               false -> "function"
           end,
     hsep(lists:map(Mod, Attrs) ++ [letdecl(Fun, D)]);
-decl(D = {letval, _, _, _, _}) -> letdecl("let", D).
+decl(D = {letval, _, _, _}) -> letdecl("let", D).
 
 -spec pragma(aeso_syntax:pragma()) -> doc().
 pragma({compiler, Op, Ver}) ->
@@ -193,8 +193,8 @@ name({tvar, _, Name})  -> text(Name);
 name({typed, _, Name, _}) -> name(Name).
 
 -spec letdecl(string(), aeso_syntax:letbind()) -> doc().
-letdecl(Let, {letval, _, F, T, E}) ->
-    block_expr(0, hsep([text(Let), typed(name(F), T), text("=")]), E);
+letdecl(Let, {letval, _, P, E}) ->
+    block_expr(0, hsep([text(Let), expr(P), text("=")]), E);
 letdecl(Let, {letfun, _, F, Args, T, E}) ->
     block_expr(0, hsep([text(Let), typed(beside(name(F), args(Args)), T), text("=")]), E).
 
@@ -459,7 +459,7 @@ elim1(Get={map_get, _, _})    -> elim(Get);
 elim1(Get={map_get, _, _, _}) -> elim(Get).
 
 alt({'case', _, Pat, Body}) ->
-    block_expr(0, hsep(expr_p(500, Pat), text("=>")), Body).
+    block_expr(0, hsep(expr(Pat), text("=>")), Body).
 
 block_expr(_, Header, {block, _, Ss}) ->
     block(Header, statements(Ss));
@@ -469,7 +469,7 @@ block_expr(P, Header, E) ->
 statements(Stmts) ->
     above([ statement(S) || S <- Stmts ]).
 
-statement(S = {letval, _, _, _, _})    -> letdecl("let", S);
+statement(S = {letval, _, _, _})       -> letdecl("let", S);
 statement(S = {letfun, _, _, _, _, _}) -> letdecl("let", S);
 statement(E) -> expr(E).
 

--- a/src/aeso_syntax.erl
+++ b/src/aeso_syntax.erl
@@ -47,7 +47,7 @@
 -type pragma() :: {compiler, '==' | '<' | '>' | '=<' | '>=', compiler_version()}.
 
 -type letbind()
-    :: {letval, ann(), id(), type(), expr()}
+    :: {letval, ann(), pat(), expr()}
      | {letfun, ann(), id(), [arg()], type(), expr()}.
 
 -type arg() :: {arg, ann(), id(), type()}.
@@ -112,7 +112,7 @@
 
 -type record_or_map() :: record | map | record_or_map_error.
 
--type comprehension_exp() :: [ {comprehension_bind, id(), expr()}
+-type comprehension_exp() :: [ {comprehension_bind, pat(), expr()}
                              | {comprehension_if, ann(), expr()}
                              | letbind() ].
 
@@ -140,6 +140,7 @@
 -type pat() :: {app, ann(), con() | op(), [pat()]}
              | {tuple, ann(), [pat()]}
              | {list, ann(), [pat()]}
+             | {typed, ann(), pat(), type()}
              | {record, ann(), [field(pat())]}
              | constant()
              | con()

--- a/src/aeso_syntax_utils.erl
+++ b/src/aeso_syntax_utils.erl
@@ -48,7 +48,7 @@ fold(Alg = #alg{zero = Zero, plus = Plus, scoped = Scoped}, Fun, K, X) ->
             {type_decl, _, I, _}     -> BindType(I);
             {type_def, _, I, _, D}   -> Plus(BindType(I), Decl(D));
             {fun_decl, _, _, T}      -> Type(T);
-            {letval, _, F, T, E}     -> Sum([BindExpr(F), Type(T), Expr(E)]);
+            {letval, _, P, E}        -> Scoped(BindExpr(P), Expr(E));
             {letfun, _, F, Xs, T, E} -> Sum([BindExpr(F), Type(T), Expr(Xs ++ [E])]);
             %% typedef()
             {alias_t, T}    -> Type(T);
@@ -76,8 +76,8 @@ fold(Alg = #alg{zero = Zero, plus = Plus, scoped = Scoped}, Fun, K, X) ->
                 Plus(Expr(E), Scoped(BindExpr(I), Expr({list_comp, A, Y, R})));
             {list_comp, A, Y, [{comprehension_if, _, E}|R]} ->
                 Plus(Expr(E), Expr({list_comp, A, Y, R}));
-            {list_comp, A, Y, [D = {letval, _, F, _, _} | R]} ->
-                Plus(Decl(D), Scoped(BindExpr(F), Expr({list_comp, A, Y, R})));
+            {list_comp, A, Y, [D = {letval, _, Pat, _} | R]} ->
+                Plus(Decl(D), Scoped(BindExpr(Pat), Expr({list_comp, A, Y, R})));
             {list_comp, A, Y, [D = {letfun, _, F, _, _, _} | R]} ->
                 Plus(Decl(D), Scoped(BindExpr(F), Expr({list_comp, A, Y, R})));
             {typed, _, E, T}       -> Plus(Expr(E), Type(T));

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -163,7 +163,8 @@ compilable_contracts() ->
      "payable",
      "unapplied_builtins",
      "underscore_number_literals",
-     "qualified_constructor"
+     "qualified_constructor",
+     "let_patterns"
     ].
 
 not_yet_compilable(fate) -> [];

--- a/test/aeso_parser_tests.erl
+++ b/test/aeso_parser_tests.erl
@@ -78,7 +78,7 @@ parse_string(Text, Opts) ->
     aeso_parser:string(Text, Opts).
 
 parse_expr(Text) ->
-    [{letval, _, _, _, Expr}] =
+    [{letval, _, _, Expr}] =
         parse_string("let _ = " ++ Text),
     Expr.
 

--- a/test/contracts/let_patterns.aes
+++ b/test/contracts/let_patterns.aes
@@ -1,0 +1,13 @@
+contract LetPatterns =
+
+  record r = {x : int, y : int, b : bool}
+
+  entrypoint test() = foo([1, 0], (2, 3), Some(4), {x = 5, y = 6, b = false})
+
+  entrypoint foo(xs : list(int), p : int * int, some : option(int), r : r) =
+    let x :: _  = xs
+    let (a, b)  = p
+    let Some(n) = some
+    let {x = i, y = j} = r
+    x + a + b + n + i + j
+

--- a/test/contracts/let_patterns.aes
+++ b/test/contracts/let_patterns.aes
@@ -11,3 +11,5 @@ contract LetPatterns =
     let {x = i, y = j} = r
     x + a + b + n + i + j
 
+  entrypoint lc(xs : list(option(int))) : list(int) =
+    [ x | Some(x) <- xs ]


### PR DESCRIPTION
Fixes #194 

~~Work-in-progress. Sits on top of #205.~~

Also adds pattern matching is list comprehension generators
```sophia
function somes(xs : list(option('a))) = [ x | Some(x) <- xs ]
```

Also also
- fix pattern matching on negative integers
- compile FATE values to immediates (e.g. `[1, 2, 3]` is compiled to `PUSH [1, 2, 3]` instead of a series of `CONS` instructions)