### PR TITLE
Allow assigning patterns to variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Set` stdlib
 - `Option.force_msg`
 - Loading namespaces into the current scope (e.g. `using Pair`)
+- Assign patterns to variables
 ### Changed
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Set` stdlib
 - `Option.force_msg`
 - Loading namespaces into the current scope (e.g. `using Pair`)
-- Assign patterns to variables
+- Assign patterns to variables (e.g. `let x::(t = y::_) = [1, 2, 3, 4]` where `t == [2, 3, 4]`)
 ### Changed
 ### Removed
 

--- a/docs/sophia_features.md
+++ b/docs/sophia_features.md
@@ -471,6 +471,17 @@ function
   get_left(Both(x, _)) = Some(x)
 ```
 
+Sophia also supports the assignment of patterns to variables:
+```sophia
+function f(x) = switch(x)
+  h1::(t = h2::_) => (h1 + h2)::t  // same as `h1::h2::k => (h1 + h2)::h2::k`
+  _ => x
+
+function g(p : int * option(int)) : int =
+  let (a, (o = Some(b))) = p  // o is equal to Pair.snd(p)
+  b
+```
+
 *NOTE: Data types cannot currently be recursive.*
 
 ## Lists

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -1705,7 +1705,7 @@ infer_expr(Env, {lam, Attrs, Args, Body}) ->
     {typed, Attrs, {lam, Attrs, NewArgs, NewBody}, {fun_t, Attrs, [], ArgTypes, ResultType}};
 infer_expr(Env, {letpat, Attrs, Id, Pattern}) ->
     NewPattern = {typed, _, _, PatType} = infer_expr(Env, Pattern),
-    {typed, Attrs, {letpat, Attrs, {typed, Attrs, Id, PatType}, NewPattern}, PatType};
+    {typed, Attrs, {letpat, Attrs, check_expr(Env, Id, PatType), NewPattern}, PatType};
 infer_expr(Env, Let = {letval, Attrs, _, _}) ->
     type_error({missing_body_for_let, Attrs}),
     infer_expr(Env, {block, Attrs, [Let, abort_expr(Attrs, "missing body")]});

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -1994,7 +1994,11 @@ rename_spat(Ren, {con, Ar, C, Xs}) ->
     {{con, Ar, C, Zs}, Ren1};
 rename_spat(Ren, {tuple, Xs}) ->
     {Zs, Ren1} = rename_bindings(Ren, Xs),
-    {{tuple, Zs}, Ren1}.
+    {{tuple, Zs}, Ren1};
+rename_spat(Ren, {assign, X, P}) ->
+    {X1, Ren1} = rename_binding(Ren, X),
+    {P1, Ren2} = rename_binding(Ren1, P),
+    {{assign, X1, P1}, Ren2}.
 
 rename_split(Ren, {split, Type, X, Cases}) ->
     {split, Type, rename_var(Ren, X), [rename_case(Ren, C) || C <- Cases]};

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -96,7 +96,8 @@
                      | nil
                      | {'::', var_name(), var_name()}
                      | {con, arities(), tag(), [var_name()]}
-                     | {tuple, [var_name()]}.
+                     | {tuple, [var_name()]}
+                     | {assign, var_name(), var_name()}.
 
 -type ftype() :: integer
                | boolean
@@ -875,7 +876,8 @@ alts_to_fcode(Env, Type, X, Alts) ->
               | {string, binary()}
               | nil | {'::', fpat(), fpat()}
               | {tuple, [fpat()]}
-              | {con, arities(), tag(), [fpat()]}.
+              | {con, arities(), tag(), [fpat()]}
+              | {assign, fpat(), fpat()}.
 
 %% %% Invariant: the number of variables matches the number of patterns in each falt.
 -spec split_tree(env(), [{var_name(), ftype()}], [falt()]) -> fsplit().
@@ -975,6 +977,8 @@ split_pat({'::', P, Q}) -> {{'::', fresh_name(), fresh_name()}, [P, Q]};
 split_pat({con, As, I, Pats}) ->
     Xs = [fresh_name() || _ <- Pats],
     {{con, As, I, Xs}, Pats};
+split_pat({assign, X = {var, _}, P}) ->
+    {{assign, fresh_name(), fresh_name()}, [X, P]};
 split_pat({tuple, Pats}) ->
     Xs = [fresh_name() || _ <- Pats],
     {{tuple, Xs}, Pats}.
@@ -985,6 +989,7 @@ split_vars({int, _},    integer)     -> [];
 split_vars({string, _}, string)      -> [];
 split_vars(nil,         {list, _})   -> [];
 split_vars({'::', X, Xs}, {list, T}) -> [{X, T}, {Xs, {list, T}}];
+split_vars({assign, X, P}, T)        -> [{X, T}, {P, T}];
 split_vars({con, _, I, Xs}, {variant, Cons}) ->
     lists:zip(Xs, lists:nth(I + 1, Cons));
 split_vars({tuple, Xs}, {tuple, Ts}) ->
@@ -1040,6 +1045,8 @@ pat_to_fcode(Env, {record_t, Fields}, {record, _, FieldPats}) ->
                     end end,
     make_tuple([pat_to_fcode(Env, FieldPat(Field))
                 || Field <- Fields]);
+pat_to_fcode(Env, _Type, {letpat, _, Id = {typed, _, {id, _, _}, _}, Pattern}) ->
+    {assign, pat_to_fcode(Env, Id), pat_to_fcode(Env, Pattern)};
 
 pat_to_fcode(_Env, Type, Pat) ->
     error({todo, Pat, ':', Type}).
@@ -1530,6 +1537,7 @@ match_pat(L, {lit, L})                      -> [];
 match_pat(nil, nil)                         -> [];
 match_pat({'::', X, Y}, {op, '::', [A, B]}) -> [{X, A}, {Y, B}];
 match_pat({var, X}, E)                      -> [{X, E}];
+match_pat({assign, X, P}, E)                -> [{X, E}, {P, E}];
 match_pat(_, _)                             -> false.
 
 constructor_form(Env, Expr) ->
@@ -1765,6 +1773,7 @@ pat_vars(nil)                 -> [];
 pat_vars({'::', P, Q})        -> pat_vars(P) ++ pat_vars(Q);
 pat_vars({tuple, Ps})         -> pat_vars(Ps);
 pat_vars({con, _, _, Ps})     -> pat_vars(Ps);
+pat_vars({assign, X, P})      -> pat_vars(X) ++ pat_vars(P);
 pat_vars(Ps) when is_list(Ps) -> [X || P <- Ps, X <- pat_vars(P)].
 
 -spec fsplit_pat_vars(fsplit_pat()) -> [var_name()].

--- a/src/aeso_pretty.erl
+++ b/src/aeso_pretty.erl
@@ -299,6 +299,8 @@ tuple_type(Factors) ->
       ]).
 
 -spec expr_p(integer(), aeso_syntax:arg_expr()) -> doc().
+expr_p(P, {letpat, _, Id, Pat}) ->
+    paren(P > 100, follow(hsep(expr(Id), text("=")), expr(Pat)));
 expr_p(P, {named_arg, _, Name, E}) ->
     paren(P > 100, follow(hsep(expr(Name), text("=")), expr(E)));
 expr_p(P, {lam, _, Args, E}) ->

--- a/src/aeso_syntax.erl
+++ b/src/aeso_syntax.erl
@@ -58,6 +58,7 @@
 
 -type letval()  :: {letval, ann(), pat(), expr()}.
 -type letfun()  :: {letfun, ann(), id(), [pat()], type(), expr()}.
+-type letpat()  :: {letpat, ann(), id(), pat()}.
 -type fundecl() :: {fun_decl, ann(), id(), type()}.
 
 -type letbind()
@@ -122,7 +123,8 @@
      | {block, ann(), [stmt()]}
      | {op(), ann()}
      | id() | qid() | con() | qcon()
-     | constant().
+     | constant()
+     | letpat().
 
 -type record_or_map() :: record | map | record_or_map_error.
 
@@ -156,6 +158,7 @@
              | {list, ann(), [pat()]}
              | {typed, ann(), pat(), type()}
              | {record, ann(), [field(pat())]}
+             | letpat()
              | constant()
              | con()
              | id().

--- a/src/aeso_syntax_utils.erl
+++ b/src/aeso_syntax_utils.erl
@@ -88,7 +88,7 @@ fold(Alg = #alg{zero = Zero, plus = Plus, scoped = Scoped}, Fun, K, X) ->
             {map_get, _, A, B}     -> Expr([A, B]);
             {map_get, _, A, B, C}  -> Expr([A, B, C]);
             {block, _, Ss}         -> Expr(Ss);
-            {letpat, _, X, P}      -> Scoped(BindExpr(X), Expr(P));
+            {letpat, _, X, P}      -> Plus(BindExpr(X), Expr(P));
             %% field()
             {field, _, LV, E}    -> Expr([LV, E]);
             {field, _, LV, _, E} -> Expr([LV, E]);

--- a/src/aeso_syntax_utils.erl
+++ b/src/aeso_syntax_utils.erl
@@ -88,6 +88,7 @@ fold(Alg = #alg{zero = Zero, plus = Plus, scoped = Scoped}, Fun, K, X) ->
             {map_get, _, A, B}     -> Expr([A, B]);
             {map_get, _, A, B, C}  -> Expr([A, B, C]);
             {block, _, Ss}         -> Expr(Ss);
+            {letpat, _, X, P}      -> Scoped(BindExpr(X), Expr(P));
             %% field()
             {field, _, LV, E}    -> Expr([LV, E]);
             {field, _, LV, _, E} -> Expr([LV, E]);

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -201,6 +201,7 @@ compilable_contracts() ->
      "create",
      "child_contract_init_bug",
      "using_namespace",
+     "assign_patterns",
      "test" % Custom general-purpose test file. Keep it last on the list.
     ].
 
@@ -236,6 +237,7 @@ failing_contracts() ->
     , ?PARSE_ERROR(vsemi,  [<<?Pos(3, 3) "Unexpected indentation. Did you forget a '}'?">>])
     , ?PARSE_ERROR(vclose, [<<?Pos(4, 3) "Unexpected indentation. Did you forget a ']'?">>])
     , ?PARSE_ERROR(indent_fail, [<<?Pos(3, 2) "Unexpected token 'entrypoint'.">>])
+    , ?PARSE_ERROR(assign_pattern_to_pattern, [<<?Pos(3, 22) "Unexpected token '='.">>])
 
     %% Type errors
     , ?TYPE_ERROR(name_clash,

--- a/test/contracts/assign_pattern_to_pattern.aes
+++ b/test/contracts/assign_pattern_to_pattern.aes
@@ -1,0 +1,4 @@
+contract AssignPatternToPattern =
+    entrypoint f() =
+        let x::(t::z = y) = [1, 2, 3]
+        (x + t)::y

--- a/test/contracts/assign_patterns.aes
+++ b/test/contracts/assign_patterns.aes
@@ -1,0 +1,16 @@
+include "List.aes"
+
+contract AssignPatterns =
+
+  entrypoint test() = foo([1, 0, 2], (2, Some(3)), Some([4, 5]))
+
+  entrypoint foo(xs : list(int), p : int * option(int), some : option(list(int))) =
+    let x::(t = y::_)  = xs
+    let z::_ = t
+
+    let (a, (o = Some(b)))  = p
+
+    let Some((f = g::_)) = some
+    g + List.get(1, f)
+
+    x + y + z + a + b


### PR DESCRIPTION
Fixes #231

Examples of the new syntax can be found in the file `test/contracts/assign_patterns.aes`.