### PR TITLE
Add compiler warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Compiler warnings for the follwing: shadowing, negative spends, division by zero, unused functions, unused includes, unused stateful annotations, unused variables, unused parameters, unused user-defined type, dead return value.
 ### Changed
 ### Removed
 

--- a/src/aeso_aci.erl
+++ b/src/aeso_aci.erl
@@ -70,7 +70,7 @@ do_contract_interface(Type, Contract, Options) when is_binary(Contract) ->
 do_contract_interface(Type, ContractString, Options) ->
     try
         Ast = aeso_compiler:parse(ContractString, Options),
-        {TypedAst, _} = aeso_ast_infer_types:infer(Ast, [dont_unfold | Options]),
+        {TypedAst, _, _} = aeso_ast_infer_types:infer(Ast, [dont_unfold | Options]),
         from_typed_ast(Type, TypedAst)
     catch
         throw:{error, Errors} -> {error, Errors}

--- a/src/aeso_errors.erl
+++ b/src/aeso_errors.erl
@@ -36,6 +36,7 @@
         , pos/2
         , pos/3
         , pp/1
+        , pp_pos/1
         , to_json/1
         , throw/1
         , type/1

--- a/src/aeso_parse_lib.erl
+++ b/src/aeso_parse_lib.erl
@@ -15,7 +15,8 @@
          many/1, many1/1, sep/2, sep1/2,
          infixl/2, infixr/2]).
 
--export([current_file/0, set_current_file/1]).
+-export([current_file/0, set_current_file/1,
+         current_include_type/0, set_current_include_type/1]).
 
 %% -- Types ------------------------------------------------------------------
 
@@ -464,6 +465,13 @@ merge_with(Fun, Map1, Map2) ->
                             maps:update_with(K, fun(R) -> Fun(L, R) end, L, M)
                         end, Map2, maps:to_list(Map1))
     end.
+
+%% Current include type
+current_include_type() ->
+    get('$current_include_type').
+
+set_current_include_type(IncludeType) ->
+    put('$current_include_type', IncludeType).
 
 %% Current source file
 current_file() ->

--- a/src/aeso_warnings.erl
+++ b/src/aeso_warnings.erl
@@ -1,0 +1,27 @@
+-module(aeso_warnings).
+
+-record(warn, { pos     :: aeso_errors:pos()
+              , message :: iolist()
+              }).
+
+-opaque warning() :: #warn{}.
+
+-export_type([warning/0]).
+
+-export([ new/1
+        , new/2
+        , warn_to_err/2
+        , pp/1
+        ]).
+
+new(Msg) ->
+    new(aeso_errors:pos(0, 0), Msg).
+
+new(Pos, Msg) ->
+    #warn{ pos = Pos, message = Msg }.
+
+warn_to_err(Kind, #warn{ pos = Pos, message = Msg }) ->
+    aeso_errors:new(Kind, Pos, lists:flatten(Msg)).
+
+pp(#warn{ pos = Pos, message = Msg }) ->
+    lists:flatten(io_lib:format("Warning~s:\n~s", [aeso_errors:pp_pos(Pos), Msg])).

--- a/test/contracts/warnings.aes
+++ b/test/contracts/warnings.aes
@@ -1,0 +1,49 @@
+// Used include
+include "Pair.aes"
+// Unused include
+include "Triple.aes"
+
+namespace UnusedNamespace =
+  function f() = 1 + g()
+
+  // Used in f
+  private function g() = 2
+
+  // Unused
+  private function h() = 3
+
+contract Warnings =
+
+  type state = int
+
+  type unused_type = bool
+
+  entrypoint init(p) = Pair.fst(p) + Pair.snd(p)
+
+  stateful entrypoint negative_spend(to : address) = Chain.spend(to, -1)
+
+  entrypoint shadowing() =
+    let x = 1
+    let x = 2
+    x
+
+  entrypoint division_by_zero(x) = x / 0
+
+  stateful entrypoint unused_stateful() = 1
+  stateful entrypoint used_stateful(x : int) = put(x)
+
+  entrypoint unused_variables(unused_arg : int) =
+    let unused_var = 10
+    let z = 20
+    z
+
+  // Unused functions
+  function unused_function() = ()
+  function recursive_unused_function() = recursive_unused_function()
+  function called_unused_function1() = called_unused_function2()
+  function called_unused_function2() = called_unused_function1()
+
+  function rv() = 1
+  entrypoint unused_return_value() =
+    rv()
+    2


### PR DESCRIPTION
Currently added warnings:

- [x] shadowing
- [x] negative spends
- [x] division by zero
- [x] unused functions
- [x] unused includes
- [x] unused `stateful` annotations
- [x] unused variables
- [x] unused parameters
- [x] unused user-defined type
- [x] dead return value
- [ ] ~non-exhaustive patterns~ (this will be tricky and should better be done in a separate PR)

Currently supported options:

- [x] Turn options off/on separately.
- [x] Warnings packages (Wall). pedantic package can easily be added later.
- [x] Turn warnings into type errors.

Things that still need to be done:
- [x] Properly report the warnings on compilation. (Currently they are just stored but not reported)

Testing:
- [x] Tests for all added warnings
- [x] Test for turning warnings into type errors