### PR TITLE
Simplify error messages reported by the compiler

### DIFF
--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -2941,7 +2941,7 @@ mk_error({mismatched_decl_in_funblock, Name, Decl}) ->
     Msg = io_lib:format("Mismatch in the function block. Expected implementation/type declaration of ~s function", [Name]),
     mk_t_err(pos(Decl), Msg);
 mk_error({higher_kinded_typevar, T}) ->
-    Msg = io_lib:format("Type ~s is a higher kinded type variable "
+    Msg = io_lib:format("Type `~s` is a higher kinded type variable "
                         "(takes another type as an argument)", [pp(instantiate(T))]
                        ),
     mk_t_err(pos(T), Msg);
@@ -2954,7 +2954,7 @@ mk_error({unnamed_map_update_with_default, Upd}) ->
     Msg = "Invalid map update with default",
     mk_t_err(pos(Upd), Msg);
 mk_error({fundecl_must_have_funtype, _Ann, Id, Type}) ->
-    Msg = io_lib:format("~s was declared with an invalid type ~s. "
+    Msg = io_lib:format("`~s` was declared with an invalid type `~s`. "
                        "Entrypoints and functions must have functional types"
                        , [pp(Id), pp(instantiate(Type))]),
     mk_t_err(pos(Id), Msg);
@@ -2965,7 +2965,7 @@ mk_error({cannot_unify, A, B, When}) ->
     {Pos, Ctxt} = pp_when(When),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({unbound_variable, Id}) ->
-    Msg = io_lib:format("Unbound variable ~s", [pp(Id)]),
+    Msg = io_lib:format("Unbound variable `~s`", [pp(Id)]),
     case Id of
         {qid, _, ["Chain", "event"]} ->
             Cxt = "Did you forget to define the event type?",
@@ -2976,7 +2976,7 @@ mk_error({undefined_field, Id}) ->
     Msg = io_lib:format("Unbound field ~s", [pp(Id)]),
     mk_t_err(pos(Id), Msg);
 mk_error({not_a_record_type, Type, Why}) ->
-    Msg = io_lib:format("~s", [pp_type("Not a record type: ", Type)]),
+    Msg = io_lib:format("Not a record type: `~s`", [pp_type(Type)]),
     {Pos, Ctxt} = pp_why_record(Why),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({not_a_contract_type, Type, Cxt}) ->
@@ -2986,7 +2986,7 @@ mk_error({not_a_contract_type, Type, Cxt}) ->
             {tvar, _, _} ->
                 "Unresolved contract type\n";
             _ ->
-                io_lib:format("The type ~s is not a contract type\n", [pp_type("", Type)])
+                io_lib:format("The type ~s is not a contract type\n", [pp_type(Type)])
         end,
     {Pos, Cxt1} =
         case Cxt of
@@ -3006,9 +3006,10 @@ mk_error({not_a_contract_type, Type, Cxt}) ->
         end,
     mk_t_err(Pos, Msg, Cxt1);
 mk_error({non_linear_pattern, Pattern, Nonlinear}) ->
-    Msg = io_lib:format("Repeated name~s ~s in pattern: ~s",
-                        [plural("", "s", Nonlinear), string:join(Nonlinear, ", "),
-                         pp_expr("  ", Pattern)]),
+    Msg = io_lib:format("Repeated name~s ~s in the pattern `~s`",
+                        [plural("", "s", Nonlinear),
+                         string:join(lists:map(fun(F) -> "`" ++ F ++ "`" end, Nonlinear), ", "),
+                         pp_expr(Pattern)]),
     mk_t_err(pos(Pattern), Msg);
 mk_error({ambiguous_record, Fields = [{_, First} | _], Candidates}) ->
     % TODO(mk_error)
@@ -3017,17 +3018,19 @@ mk_error({ambiguous_record, Fields = [{_, First} | _], Candidates}) ->
                         pp_loc(First), [ ["  - ", pp(C), " (at ", pp_loc(C), ")\n"] || C <- Candidates ]]),
     mk_t_err(pos(First), Msg);
 mk_error({missing_field, Field, Rec}) ->
-    Msg = io_lib:format("Record type ~s does not have field ~s",
+    Msg = io_lib:format("Record type `~s` does not have field `~s`",
                         [pp(Rec), pp(Field)]),
     mk_t_err(pos(Field), Msg);
 mk_error({missing_fields, Ann, RecType, Fields}) ->
-    Msg = io_lib:format("The field~s ~s ~s missing when constructing an element of type ~s",
-                        [plural("", "s", Fields), string:join(Fields, ", "),
+    Msg = io_lib:format("The field~s ~s ~s missing when constructing an element of type `~s`",
+                        [plural("", "s", Fields),
+                         string:join(lists:map(fun(F) -> "`" ++ F ++ "`" end, Fields), ", "),
                          plural("is", "are", Fields), pp(RecType)]),
     mk_t_err(pos(Ann), Msg);
 mk_error({no_records_with_all_fields, Fields = [{_, First} | _]}) ->
     Msg = io_lib:format("No record type with field~s ~s",
-                        [plural("", "s", Fields), string:join([ pp(F) || {_, F} <- Fields ], ", ")]),
+                        [plural("", "s", Fields),
+                         string:join(lists:map(fun(F) -> "`" ++ F ++ "`" end, [ pp(F) || {_, F} <- Fields ]), ", ")]),
     mk_t_err(pos(First), Msg);
 mk_error({recursive_types_not_implemented, Types}) ->
     % TODO(mk_error)
@@ -3039,19 +3042,19 @@ mk_error({event_must_be_variant_type, Where}) ->
     Msg = io_lib:format("The event type must be a variant type", []),
     mk_t_err(pos(Where), Msg);
 mk_error({indexed_type_must_be_word, Type, Type}) ->
-    Msg = io_lib:format("The indexed type ~s is not a word type",
-                        [pp_type("", Type)]),
+    Msg = io_lib:format("The indexed type `~s` is not a word type",
+                        [pp_type(Type)]),
     mk_t_err(pos(Type), Msg);
 mk_error({indexed_type_must_be_word, Type, Type1}) ->
-    Msg = io_lib:format("The indexed type ~s equals ~s which is not a word type",
-                        [pp_type("", Type), pp_type("", Type1)]),
+    Msg = io_lib:format("The indexed type `~s` equals `~s` which is not a word type",
+                        [pp_type(Type), pp_type(Type1)]),
     mk_t_err(pos(Type), Msg);
 mk_error({event_0_to_3_indexed_values, Constr}) ->
-    Msg = io_lib:format("The event constructor ~s has too many indexed values (max 3)",
+    Msg = io_lib:format("The event constructor `~s` has too many indexed values (max 3)",
                         [name(Constr)]),
     mk_t_err(pos(Constr), Msg);
 mk_error({event_0_to_1_string_values, Constr}) ->
-    Msg = io_lib:format("The event constructor ~s has too many non-indexed values (max 1)",
+    Msg = io_lib:format("The event constructor `~s` has too many non-indexed values (max 1)",
                         [name(Constr)]),
     mk_t_err(pos(Constr), Msg);
 mk_error({repeated_constructor, Cs}) ->
@@ -3084,40 +3087,40 @@ mk_error({duplicate_definition, Name, Locs}) ->
                         [Name, [ ["  - ", pp_loc(L), "\n"] || L <- Locs ]]),
     mk_t_err(pos(lists:last(Locs)), Msg);
 mk_error({duplicate_scope, Kind, Name, OtherKind, L}) ->
-    Msg = io_lib:format("The ~p ~s has the same name as a ~p at ~s",
+    Msg = io_lib:format("The ~p `~s` has the same name as a ~p at ~s",
                         [Kind, pp(Name), OtherKind, pp_loc(L)]),
     mk_t_err(pos(Name), Msg);
 mk_error({include, _, {string, Pos, Name}}) ->
-    Msg = io_lib:format("Include of '~s' is not allowed, include only allowed at top level.",
+    Msg = io_lib:format("Include of `~s` is not allowed, include only allowed at top level.",
                         [binary_to_list(Name)]),
     mk_t_err(pos(Pos), Msg);
 mk_error({namespace, _Pos, {con, Pos, Name}, _Def}) ->
-    Msg = io_lib:format("Nested namespaces are not allowed. Namespace '~s' not defined at top level.",
+    Msg = io_lib:format("Nested namespaces are not allowed. Namespace `~s` is not defined at top level.",
                         [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({Contract, _Pos, {con, Pos, Name}, _Def}) when ?IS_CONTRACT_HEAD(Contract) ->
-    Msg = io_lib:format("Nested contracts are not allowed. Contract '~s' not defined at top level.",
+    Msg = io_lib:format("Nested contracts are not allowed. Contract `~s` is not defined at top level.",
                         [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({type_decl, _, {id, Pos, Name}, _}) ->
-    Msg = io_lib:format("Empty type declarations are not supported. Type ~s lacks a definition",
+    Msg = io_lib:format("Empty type declarations are not supported. Type `~s` lacks a definition",
                         [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({letval, _Pos, {id, Pos, Name}, _Def}) ->
-    Msg = io_lib:format("Toplevel \"let\" definitions are not supported. Value ~s could be replaced by 0-argument function.",
+    Msg = io_lib:format("Toplevel \"let\" definitions are not supported. Value `~s` could be replaced by 0-argument function.",
                         [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({stateful_not_allowed, Id, Fun}) ->
-    Msg = io_lib:format("Cannot reference stateful function ~s in the definition of non-stateful function ~s.",
+    Msg = io_lib:format("Cannot reference stateful function `~s` in the definition of non-stateful function `~s`.",
                         [pp(Id), pp(Fun)]),
     mk_t_err(pos(Id), Msg);
 mk_error({stateful_not_allowed_in_guards, Id}) ->
-    Msg = io_lib:format("Cannot reference stateful function ~s in a pattern guard.",
+    Msg = io_lib:format("Cannot reference stateful function `~s` in a pattern guard.",
                         [pp(Id)]),
     mk_t_err(pos(Id), Msg);
 mk_error({value_arg_not_allowed, Value, Fun}) ->
-    Msg = io_lib:format("Cannot pass non-zero value argument ~s in the definition of non-stateful function ~s.",
-                        [pp_expr("", Value), pp(Fun)]),
+    Msg = io_lib:format("Cannot pass non-zero value argument `~s` in the definition of non-stateful function `~s`.",
+                        [pp_expr(Value), pp(Fun)]),
     mk_t_err(pos(Value), Msg);
 mk_error({init_depends_on_state, Which, [_Init | Chain]}) ->
     % TODO(mk_error)
@@ -3132,9 +3135,9 @@ mk_error({missing_body_for_let, Ann}) ->
     mk_t_err(pos(Ann), Msg);
 mk_error({public_modifier_in_contract, Decl}) ->
     Decl1 = mk_entrypoint(Decl),
-    Msg = io_lib:format("Use 'entrypoint' instead of 'function' for public function `~s`: `~s`",
+    Msg = io_lib:format("Use `entrypoint` instead of `function` for public function `~s`: `~s`",
                         [pp_expr(element(3, Decl)),
-                         prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
+                         prettypr:format(aeso_pretty:decl(Decl1))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({init_must_be_an_entrypoint, Decl}) ->
     Decl1 = mk_entrypoint(Decl),
@@ -3149,35 +3152,35 @@ mk_error({init_must_not_be_payable, Decl}) ->
     mk_t_err(pos(Decl), Msg);
 mk_error({proto_must_be_entrypoint, Decl}) ->
     Decl1 = mk_entrypoint(Decl),
-    Msg = io_lib:format("Use 'entrypoint' for declaration of `~s`: `~s`",
+    Msg = io_lib:format("Use `entrypoint` for declaration of `~s`: `~s`",
                         [pp_expr(element(3, Decl)),
-                         prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
+                         prettypr:format(aeso_pretty:decl(Decl1))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({proto_in_namespace, Decl}) ->
     Msg = io_lib:format("Namespaces cannot contain function prototypes.", []),
     mk_t_err(pos(Decl), Msg);
 mk_error({entrypoint_in_namespace, Decl}) ->
-    Msg = io_lib:format("Namespaces cannot contain entrypoints. Use 'function' instead.", []),
+    Msg = io_lib:format("Namespaces cannot contain entrypoints. Use `function` instead.", []),
     mk_t_err(pos(Decl), Msg);
 mk_error({private_entrypoint, Decl}) ->
-    Msg = io_lib:format("The entrypoint ~s cannot be private. Use 'function' instead.",
-                        [pp_expr("", element(3, Decl))]),
+    Msg = io_lib:format("The entrypoint `~s` cannot be private. Use `function` instead.",
+                        [pp_expr(element(3, Decl))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({private_and_public, Decl}) ->
-    Msg = io_lib:format("The function ~s cannot be both public and private.",
-                        [pp_expr("", element(3, Decl))]),
+    Msg = io_lib:format("The function `~s` cannot be both public and private.",
+                        [pp_expr(element(3, Decl))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({contract_has_no_entrypoints, Con}) ->
-    Msg = io_lib:format("The contract ~s has no entrypoints. Since Sophia version 3.2, public "
-                        "contract functions must be declared with the 'entrypoint' keyword instead of "
-                        "'function'.", [pp_expr("", Con)]),
+    Msg = io_lib:format("The contract `~s` has no entrypoints. Since Sophia version 3.2, public "
+                        "contract functions must be declared with the `entrypoint` keyword instead of "
+                        "`function`.", [pp_expr(Con)]),
     mk_t_err(pos(Con), Msg);
 mk_error({definition_in_contract_interface, Ann, {id, _, Id}}) ->
     Msg = "Contract interfaces cannot contain defined functions or entrypoints.",
-    Cxt = io_lib:format("Fix: replace the definition of '~s' by a type signature.", [Id]),
+    Cxt = io_lib:format("Fix: replace the definition of `~s` by a type signature.", [Id]),
     mk_t_err(pos(Ann), Msg, Cxt);
 mk_error({unbound_type, Type}) ->
-    Msg = io_lib:format("Unbound type ~s.", [pp_type("", Type)]),
+    Msg = io_lib:format("Unbound type ~s.", [pp_type(Type)]),
     mk_t_err(pos(Type), Msg);
 mk_error({new_tuple_syntax, Ann, Ts}) ->
     Msg = io_lib:format("Invalid type `~s`. The syntax of tuple types changed in Sophia version 4.0. Did you mean `~s`",
@@ -3192,8 +3195,8 @@ mk_error({cannot_call_init_function, Ann}) ->
           "and cannot be called from the contract code.",
     mk_t_err(pos(Ann), Msg);
 mk_error({contract_treated_as_namespace, Ann, [Con, Fun] = QName}) ->
-    Msg = io_lib:format("Invalid call to contract entrypoint '~s'.", [string:join(QName, ".")]),
-    Cxt = io_lib:format("It must be called as 'c.~s' for some c : ~s.", [Fun, Con]),
+    Msg = io_lib:format("Invalid call to contract entrypoint `~s`.", [string:join(QName, ".")]),
+    Cxt = io_lib:format("It must be called as `c.~s` for some `c : ~s`.", [Fun, Con]),
     mk_t_err(pos(Ann), Msg, Cxt);
 mk_error({bad_top_level_decl, Decl}) ->
     What = case element(1, Decl) of
@@ -3202,7 +3205,7 @@ mk_error({bad_top_level_decl, Decl}) ->
            end,
     Id = element(3, Decl),
     Msg = io_lib:format("The definition of '~s' must appear inside a ~s.",
-                        [pp_expr("", Id), What]),
+                        [pp_expr(Id), What]),
     mk_t_err(pos(Decl), Msg);
 mk_error({unknown_byte_length, Type}) ->
     Msg = io_lib:format("Cannot resolve length of byte array.", []),
@@ -3237,7 +3240,9 @@ mk_error({mixed_record_and_map, Expr}) ->
     Msg = io_lib:format("Mixed record fields and map keys in `~s`", [pp_expr(Expr)]),
     mk_t_err(pos(Expr), Msg);
 mk_error({named_argument_must_be_literal_bool, Name, Arg}) ->
-    Msg = io_lib:format("Invalid '~s' argument `~s` It must be either 'true' or 'false'.", [Name, pp_expr(instantiate(Arg))]),
+    Msg = io_lib:format("Invalid `~s` argument `~s`. "
+                        "It must be either `true` or `false`.",
+                        [Name, pp_expr(instantiate(Arg))]),
     mk_t_err(pos(Arg), Msg);
 mk_error({conflicting_updates_for_field, Upd, Key}) ->
     Msg = io_lib:format("Conflicting updates for field '~s'", [Key]),
@@ -3462,19 +3467,19 @@ pp_when(unknown) -> {pos(0,0), ""}.
 -spec pp_why_record(why_record()) -> {pos(), iolist()}.
 pp_why_record({var_args, Ann, Fun}) ->
     {pos(Ann),
-     io_lib:format("arising from resolution of variadic function ~s",
+     io_lib:format("arising from resolution of variadic function `~s`",
                    [pp_expr(Fun)])};
 pp_why_record(Fld = {field, _Ann, LV, _E}) ->
     {pos(Fld),
-     io_lib:format("arising from an assignment of the field ~s",
+     io_lib:format("arising from an assignment of the field `~s`",
                    [pp_expr({lvalue, [], LV})])};
 pp_why_record(Fld = {field, _Ann, LV, _Alias, _E}) ->
     {pos(Fld),
-     io_lib:format("arising from an assignment of the field ~s",
+     io_lib:format("arising from an assignment of the field `~s`",
                    [pp_expr({lvalue, [], LV})])};
 pp_why_record({proj, _Ann, Rec, FldName}) ->
     {pos(Rec),
-     io_lib:format("arising from the projection of the field ~s",
+     io_lib:format("arising from the projection of the field `~s`",
          [pp(FldName)])}.
 
 

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -2976,8 +2976,7 @@ mk_error({undefined_field, Id}) ->
     Msg = io_lib:format("Unbound field ~s", [pp(Id)]),
     mk_t_err(pos(Id), Msg);
 mk_error({not_a_record_type, Type, Why}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("~s\n", [pp_type("Not a record type: ", Type)]),
+    Msg = io_lib:format("~s", [pp_type("Not a record type: ", Type)]),
     {Pos, Ctxt} = pp_why_record(Why),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({not_a_contract_type, Type, Cxt}) ->
@@ -3476,20 +3475,20 @@ pp_when(unknown) -> {pos(0,0), ""}.
 -spec pp_why_record(why_record()) -> {pos(), iolist()}.
 pp_why_record({var_args, Ann, Fun}) ->
     {pos(Ann),
-     io_lib:format("arising from resolution of variadic function ~s (at ~s)",
-                   [pp_expr(Fun), pp_loc(Fun)])};
+     io_lib:format("arising from resolution of variadic function ~s",
+                   [pp_expr(Fun)])};
 pp_why_record(Fld = {field, _Ann, LV, _E}) ->
     {pos(Fld),
-     io_lib:format("arising from an assignment of the field ~s (at ~s)",
-                   [pp_expr({lvalue, [], LV}), pp_loc(Fld)])};
+     io_lib:format("arising from an assignment of the field ~s",
+                   [pp_expr({lvalue, [], LV})])};
 pp_why_record(Fld = {field, _Ann, LV, _Alias, _E}) ->
     {pos(Fld),
-     io_lib:format("arising from an assignment of the field ~s (at ~s)",
-                   [pp_expr({lvalue, [], LV}), pp_loc(Fld)])};
+     io_lib:format("arising from an assignment of the field ~s",
+                   [pp_expr({lvalue, [], LV})])};
 pp_why_record({proj, _Ann, Rec, FldName}) ->
     {pos(Rec),
-     io_lib:format("arising from the projection of the field ~s (at ~s)",
-         [pp(FldName), pp_loc(Rec)])}.
+     io_lib:format("arising from the projection of the field ~s",
+         [pp(FldName)])}.
 
 
 if_branches(If = {'if', Ann, _, Then, Else}) ->

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -2941,9 +2941,8 @@ mk_error({mismatched_decl_in_funblock, Name, Decl}) ->
     Msg = io_lib:format("Mismatch in the function block. Expected implementation/type declaration of ~s function", [Name]),
     mk_t_err(pos(Decl), Msg);
 mk_error({higher_kinded_typevar, T}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Type ~s is a higher kinded type variable\n"
-                        "(takes another type as an argument)\n", [pp(instantiate(T))]
+    Msg = io_lib:format("Type ~s is a higher kinded type variable "
+                        "(takes another type as an argument)", [pp(instantiate(T))]
                        ),
     mk_t_err(pos(T), Msg);
 mk_error({wrong_type_arguments, X, ArityGiven, ArityReal}) ->
@@ -2955,10 +2954,9 @@ mk_error({unnamed_map_update_with_default, Upd}) ->
     Msg = "Invalid map update with default",
     mk_t_err(pos(Upd), Msg);
 mk_error({fundecl_must_have_funtype, _Ann, Id, Type}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("~s at ~s was declared with an invalid type ~s.\n"
+    Msg = io_lib:format("~s was declared with an invalid type ~s. "
                        "Entrypoints and functions must have functional types"
-                       , [pp(Id), pp_loc(Id), pp(instantiate(Type))]),
+                       , [pp(Id), pp(instantiate(Type))]),
     mk_t_err(pos(Id), Msg);
 mk_error({cannot_unify, A, B, When}) ->
     % TODO(mk_error)
@@ -3009,10 +3007,9 @@ mk_error({not_a_contract_type, Type, Cxt}) ->
         end,
     mk_t_err(Pos, Msg, Cxt1);
 mk_error({non_linear_pattern, Pattern, Nonlinear}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Repeated name~s ~s in pattern\n~s (at ~s)\n",
+    Msg = io_lib:format("Repeated name~s ~s in pattern: ~s",
                         [plural("", "s", Nonlinear), string:join(Nonlinear, ", "),
-                         pp_expr("  ", Pattern), pp_loc(Pattern)]),
+                         pp_expr("  ", Pattern)]),
     mk_t_err(pos(Pattern), Msg);
 mk_error({ambiguous_record, Fields = [{_, First} | _], Candidates}) ->
     % TODO(mk_error)
@@ -3079,9 +3076,8 @@ mk_error({unsolved_named_argument_constraint, #named_argument_constraint{name = 
                         [pp_typed("", Name, Type)]),
     mk_t_err(pos(Name), Msg);
 mk_error({reserved_entrypoint, Name, Def}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("The name '~s' is reserved and cannot be used for a\n"
-                        "top-level contract function (at ~s).\n", [Name, pp_loc(Def)]),
+    Msg = io_lib:format("The name '~s' is reserved and cannot be used for a "
+                        "top-level contract function.", [Name]),
     mk_t_err(pos(Def), Msg);
 mk_error({duplicate_definition, Name, Locs}) ->
     % TODO(mk_error)
@@ -3097,24 +3093,20 @@ mk_error({include, _, {string, Pos, Name}}) ->
                         [binary_to_list(Name)]),
     mk_t_err(pos(Pos), Msg);
 mk_error({namespace, _Pos, {con, Pos, Name}, _Def}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Nested namespaces are not allowed\nNamespace '~s' at ~s not defined at top level.\n",
-                        [Name, pp_loc(Pos)]),
+    Msg = io_lib:format("Nested namespaces are not allowed. Namespace '~s' not defined at top level.",
+                        [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({Contract, _Pos, {con, Pos, Name}, _Def}) when ?IS_CONTRACT_HEAD(Contract) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Nested contracts are not allowed\nContract '~s' at ~s not defined at top level.\n",
-                        [Name, pp_loc(Pos)]),
+    Msg = io_lib:format("Nested contracts are not allowed. Contract '~s' not defined at top level.",
+                        [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({type_decl, _, {id, Pos, Name}, _}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Empty type declarations are not supported\nType ~s at ~s lacks a definition\n",
-                        [Name, pp_loc(Pos)]),
+    Msg = io_lib:format("Empty type declarations are not supported. Type ~s lacks a definition",
+                        [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({letval, _Pos, {id, Pos, Name}, _Def}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Toplevel \"let\" definitions are not supported\nValue ~s at ~s could be replaced by 0-argument function\n",
-                        [Name, pp_loc(Pos)]),
+    Msg = io_lib:format("Toplevel \"let\" definitions are not supported. Value ~s could be replaced by 0-argument function.",
+                        [Name]),
     mk_t_err(pos(Pos), Msg);
 mk_error({stateful_not_allowed, Id, Fun}) ->
     Msg = io_lib:format("Cannot reference stateful function ~s in the definition of non-stateful function ~s.",
@@ -3154,11 +3146,10 @@ mk_error({init_must_be_an_entrypoint, Decl}) ->
                          prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({init_must_not_be_payable, Decl}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("The init function (at ~s) cannot be payable.\n"
-                        "You don't need the 'payable' annotation to be able to attach\n"
+    Msg = io_lib:format("The init function cannot be payable. "
+                        "You don't need the 'payable' annotation to be able to attach "
                         "funds to the create contract transaction.",
-                        [pp_loc(Decl)]),
+                        []),
     mk_t_err(pos(Decl), Msg);
 mk_error({proto_must_be_entrypoint, Decl}) ->
     % TODO(mk_error)
@@ -3182,10 +3173,9 @@ mk_error({private_and_public, Decl}) ->
                         [pp_expr("", element(3, Decl))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({contract_has_no_entrypoints, Con}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("The contract ~s (at ~s) has no entrypoints. Since Sophia version 3.2, public\n"
-                        "contract functions must be declared with the 'entrypoint' keyword instead of\n"
-                        "'function'.\n", [pp_expr("", Con), pp_loc(Con)]),
+    Msg = io_lib:format("The contract ~s has no entrypoints. Since Sophia version 3.2, public "
+                        "contract functions must be declared with the 'entrypoint' keyword instead of "
+                        "'function'.", [pp_expr("", Con)]),
     mk_t_err(pos(Con), Msg);
 mk_error({definition_in_contract_interface, Ann, {id, _, Id}}) ->
     Msg = "Contract interfaces cannot contain defined functions or entrypoints.",
@@ -3205,9 +3195,8 @@ mk_error({map_in_map_key, Ann, KeyType}) ->
     Cxt = "Map keys cannot contain other maps.\n",
     mk_t_err(pos(Ann), Msg, Cxt);
 mk_error({cannot_call_init_function, Ann}) ->
-    % TODO(mk_error)
-    Msg = "The 'init' function is called exclusively by the create contract transaction\n"
-          "and cannot be called from the contract code.\n",
+    Msg = "The 'init' function is called exclusively by the create contract transaction "
+          "and cannot be called from the contract code.",
     mk_t_err(pos(Ann), Msg);
 mk_error({contract_treated_as_namespace, Ann, [Con, Fun] = QName}) ->
     Msg = io_lib:format("Invalid call to contract entrypoint '~s'.", [string:join(QName, ".")]),

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -2936,35 +2936,38 @@ mk_t_err_from_warn(Warn) ->
 
 mk_error({no_decls, File}) ->
     Pos = aeso_errors:pos(File, 0, 0),
-    mk_t_err(Pos, "Empty contract\n");
+    mk_t_err(Pos, "Empty contract");
 mk_error({mismatched_decl_in_funblock, Name, Decl}) ->
-    Msg = io_lib:format("Mismatch in the function block. Expected implementation/type declaration of ~s function\n", [Name]),
+    Msg = io_lib:format("Mismatch in the function block. Expected implementation/type declaration of ~s function", [Name]),
     mk_t_err(pos(Decl), Msg);
 mk_error({higher_kinded_typevar, T}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Type ~s is a higher kinded type variable\n"
                         "(takes another type as an argument)\n", [pp(instantiate(T))]
                        ),
     mk_t_err(pos(T), Msg);
 mk_error({wrong_type_arguments, X, ArityGiven, ArityReal}) ->
-    Msg = io_lib:format("Arity for ~s doesn't match. Expected ~p, got ~p\n"
+    Msg = io_lib:format("Arity for ~s doesn't match. Expected ~p, got ~p"
                        , [pp(instantiate(X)), ArityReal, ArityGiven]
                        ),
     mk_t_err(pos(X), Msg);
 mk_error({unnamed_map_update_with_default, Upd}) ->
-    Msg = "Invalid map update with default\n",
+    Msg = "Invalid map update with default",
     mk_t_err(pos(Upd), Msg);
 mk_error({fundecl_must_have_funtype, _Ann, Id, Type}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("~s at ~s was declared with an invalid type ~s.\n"
                        "Entrypoints and functions must have functional types"
                        , [pp(Id), pp_loc(Id), pp(instantiate(Type))]),
     mk_t_err(pos(Id), Msg);
 mk_error({cannot_unify, A, B, When}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Cannot unify ~s\n         and ~s\n",
                         [pp(instantiate(A)), pp(instantiate(B))]),
     {Pos, Ctxt} = pp_when(When),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({unbound_variable, Id}) ->
-    Msg = io_lib:format("Unbound variable ~s at ~s\n", [pp(Id), pp_loc(Id)]),
+    Msg = io_lib:format("Unbound variable ~s", [pp(Id)]),
     case Id of
         {qid, _, ["Chain", "event"]} ->
             Cxt = "Did you forget to define the event type?",
@@ -2972,13 +2975,15 @@ mk_error({unbound_variable, Id}) ->
         _ -> mk_t_err(pos(Id), Msg)
     end;
 mk_error({undefined_field, Id}) ->
-    Msg = io_lib:format("Unbound field ~s at ~s\n", [pp(Id), pp_loc(Id)]),
+    Msg = io_lib:format("Unbound field ~s", [pp(Id)]),
     mk_t_err(pos(Id), Msg);
 mk_error({not_a_record_type, Type, Why}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("~s\n", [pp_type("Not a record type: ", Type)]),
     {Pos, Ctxt} = pp_why_record(Why),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({not_a_contract_type, Type, Cxt}) ->
+    % TODO(mk_error)
     Msg =
         case Type of
             {tvar, _, _} ->
@@ -3004,116 +3009,127 @@ mk_error({not_a_contract_type, Type, Cxt}) ->
         end,
     mk_t_err(Pos, Msg, Cxt1);
 mk_error({non_linear_pattern, Pattern, Nonlinear}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Repeated name~s ~s in pattern\n~s (at ~s)\n",
                         [plural("", "s", Nonlinear), string:join(Nonlinear, ", "),
                          pp_expr("  ", Pattern), pp_loc(Pattern)]),
     mk_t_err(pos(Pattern), Msg);
 mk_error({ambiguous_record, Fields = [{_, First} | _], Candidates}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Ambiguous record type with field~s ~s (at ~s) could be one of\n~s",
                         [plural("", "s", Fields), string:join([ pp(F) || {_, F} <- Fields ], ", "),
                         pp_loc(First), [ ["  - ", pp(C), " (at ", pp_loc(C), ")\n"] || C <- Candidates ]]),
     mk_t_err(pos(First), Msg);
 mk_error({missing_field, Field, Rec}) ->
-    Msg = io_lib:format("Record type ~s does not have field ~s (at ~s)\n",
-                        [pp(Rec), pp(Field), pp_loc(Field)]),
+    Msg = io_lib:format("Record type ~s does not have field ~s",
+                        [pp(Rec), pp(Field)]),
     mk_t_err(pos(Field), Msg);
 mk_error({missing_fields, Ann, RecType, Fields}) ->
-    Msg = io_lib:format("The field~s ~s ~s missing when constructing an element of type ~s (at ~s)\n",
+    Msg = io_lib:format("The field~s ~s ~s missing when constructing an element of type ~s",
                         [plural("", "s", Fields), string:join(Fields, ", "),
-                         plural("is", "are", Fields), pp(RecType), pp_loc(Ann)]),
+                         plural("is", "are", Fields), pp(RecType)]),
     mk_t_err(pos(Ann), Msg);
 mk_error({no_records_with_all_fields, Fields = [{_, First} | _]}) ->
-    Msg = io_lib:format("No record type with field~s ~s (at ~s)\n",
-                        [plural("", "s", Fields), string:join([ pp(F) || {_, F} <- Fields ], ", "),
-                         pp_loc(First)]),
+    Msg = io_lib:format("No record type with field~s ~s",
+                        [plural("", "s", Fields), string:join([ pp(F) || {_, F} <- Fields ], ", ")]),
     mk_t_err(pos(First), Msg);
 mk_error({recursive_types_not_implemented, Types}) ->
+    % TODO(mk_error)
     S = plural(" is", "s are mutually", Types),
     Msg = io_lib:format("The following type~s recursive, which is not yet supported:\n~s",
                         [S, [io_lib:format("  - ~s (at ~s)\n", [pp(T), pp_loc(T)]) || T <- Types]]),
     mk_t_err(pos(hd(Types)), Msg);
 mk_error({event_must_be_variant_type, Where}) ->
-    Msg = io_lib:format("The event type must be a variant type (at ~s)\n", [pp_loc(Where)]),
+    Msg = io_lib:format("The event type must be a variant type", []),
     mk_t_err(pos(Where), Msg);
 mk_error({indexed_type_must_be_word, Type, Type}) ->
-    Msg = io_lib:format("The indexed type ~s (at ~s) is not a word type\n",
-                        [pp_type("", Type), pp_loc(Type)]),
+    Msg = io_lib:format("The indexed type ~s is not a word type",
+                        [pp_type("", Type)]),
     mk_t_err(pos(Type), Msg);
 mk_error({indexed_type_must_be_word, Type, Type1}) ->
-    Msg = io_lib:format("The indexed type ~s (at ~s) equals ~s which is not a word type\n",
-                        [pp_type("", Type), pp_loc(Type), pp_type("", Type1)]),
+    Msg = io_lib:format("The indexed type ~s equals ~s which is not a word type",
+                        [pp_type("", Type), pp_type("", Type1)]),
     mk_t_err(pos(Type), Msg);
 mk_error({event_0_to_3_indexed_values, Constr}) ->
-    Msg = io_lib:format("The event constructor ~s (at ~s) has too many indexed values (max 3)\n",
-                        [name(Constr), pp_loc(Constr)]),
+    Msg = io_lib:format("The event constructor ~s has too many indexed values (max 3)",
+                        [name(Constr)]),
     mk_t_err(pos(Constr), Msg);
 mk_error({event_0_to_1_string_values, Constr}) ->
-    Msg = io_lib:format("The event constructor ~s (at ~s) has too many non-indexed values (max 1)\n",
-                        [name(Constr), pp_loc(Constr)]),
+    Msg = io_lib:format("The event constructor ~s has too many non-indexed values (max 1)",
+                        [name(Constr)]),
     mk_t_err(pos(Constr), Msg);
 mk_error({repeated_constructor, Cs}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Variant types must have distinct constructor names\n~s",
                         [[ io_lib:format("~s  (at ~s)\n", [pp_typed("  - ", C, T), pp_loc(C)]) || {C, T} <- Cs ]]),
     mk_t_err(pos(element(1, hd(Cs))), Msg);
 mk_error({bad_named_argument, [], Name}) ->
-    Msg = io_lib:format("Named argument ~s (at ~s) supplied to function expecting no named arguments.\n",
-                        [pp(Name), pp_loc(Name)]),
+    Msg = io_lib:format("Named argument ~s supplied to function expecting no named arguments.",
+                        [pp(Name)]),
     mk_t_err(pos(Name), Msg);
 mk_error({bad_named_argument, Args, Name}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Named argument ~s (at ~s) is not one of the expected named arguments\n~s",
                         [pp(Name), pp_loc(Name),
                         [ io_lib:format("~s\n", [pp_typed("  - ", Arg, Type)])
                           || {named_arg_t, _, Arg, Type, _} <- Args ]]),
     mk_t_err(pos(Name), Msg);
 mk_error({unsolved_named_argument_constraint, #named_argument_constraint{name = Name, type = Type}}) ->
-    Msg = io_lib:format("Named argument ~s (at ~s) supplied to function with unknown named arguments.\n",
-                        [pp_typed("", Name, Type), pp_loc(Name)]),
+    Msg = io_lib:format("Named argument ~s supplied to function with unknown named arguments.",
+                        [pp_typed("", Name, Type)]),
     mk_t_err(pos(Name), Msg);
 mk_error({reserved_entrypoint, Name, Def}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("The name '~s' is reserved and cannot be used for a\n"
                         "top-level contract function (at ~s).\n", [Name, pp_loc(Def)]),
     mk_t_err(pos(Def), Msg);
 mk_error({duplicate_definition, Name, Locs}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Duplicate definitions of ~s at\n~s",
                         [Name, [ ["  - ", pp_loc(L), "\n"] || L <- Locs ]]),
     mk_t_err(pos(lists:last(Locs)), Msg);
 mk_error({duplicate_scope, Kind, Name, OtherKind, L}) ->
-    Msg = io_lib:format("The ~p ~s (at ~s) has the same name as a ~p at ~s\n",
-                        [Kind, pp(Name), pp_loc(Name), OtherKind, pp_loc(L)]),
+    Msg = io_lib:format("The ~p ~s has the same name as a ~p at ~s",
+                        [Kind, pp(Name), OtherKind, pp_loc(L)]),
     mk_t_err(pos(Name), Msg);
 mk_error({include, _, {string, Pos, Name}}) ->
-    Msg = io_lib:format("Include of '~s' at ~s\nnot allowed, include only allowed at top level.\n",
-                        [binary_to_list(Name), pp_loc(Pos)]),
+    Msg = io_lib:format("Include of '~s' is not allowed, include only allowed at top level.",
+                        [binary_to_list(Name)]),
     mk_t_err(pos(Pos), Msg);
 mk_error({namespace, _Pos, {con, Pos, Name}, _Def}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Nested namespaces are not allowed\nNamespace '~s' at ~s not defined at top level.\n",
                         [Name, pp_loc(Pos)]),
     mk_t_err(pos(Pos), Msg);
 mk_error({Contract, _Pos, {con, Pos, Name}, _Def}) when ?IS_CONTRACT_HEAD(Contract) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Nested contracts are not allowed\nContract '~s' at ~s not defined at top level.\n",
                         [Name, pp_loc(Pos)]),
     mk_t_err(pos(Pos), Msg);
 mk_error({type_decl, _, {id, Pos, Name}, _}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Empty type declarations are not supported\nType ~s at ~s lacks a definition\n",
                         [Name, pp_loc(Pos)]),
     mk_t_err(pos(Pos), Msg);
 mk_error({letval, _Pos, {id, Pos, Name}, _Def}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Toplevel \"let\" definitions are not supported\nValue ~s at ~s could be replaced by 0-argument function\n",
                         [Name, pp_loc(Pos)]),
     mk_t_err(pos(Pos), Msg);
 mk_error({stateful_not_allowed, Id, Fun}) ->
-    Msg = io_lib:format("Cannot reference stateful function ~s (at ~s)\nin the definition of non-stateful function ~s.\n",
-                        [pp(Id), pp_loc(Id), pp(Fun)]),
+    Msg = io_lib:format("Cannot reference stateful function ~s in the definition of non-stateful function ~s.",
+                        [pp(Id), pp(Fun)]),
     mk_t_err(pos(Id), Msg);
 mk_error({stateful_not_allowed_in_guards, Id}) ->
-    Msg = io_lib:format("Cannot reference stateful function ~s (at ~s) in a pattern guard.\n",
-                        [pp(Id), pp_loc(Id)]),
+    Msg = io_lib:format("Cannot reference stateful function ~s in a pattern guard.",
+                        [pp(Id)]),
     mk_t_err(pos(Id), Msg);
 mk_error({value_arg_not_allowed, Value, Fun}) ->
-    Msg = io_lib:format("Cannot pass non-zero value argument ~s (at ~s)\nin the definition of non-stateful function ~s.\n",
-                        [pp_expr("", Value), pp_loc(Value), pp(Fun)]),
+    Msg = io_lib:format("Cannot pass non-zero value argument ~s in the definition of non-stateful function ~s.",
+                        [pp_expr("", Value), pp(Fun)]),
     mk_t_err(pos(Value), Msg);
 mk_error({init_depends_on_state, Which, [_Init | Chain]}) ->
+    % TODO(mk_error)
     WhichCalls = fun("put") -> ""; ("state") -> ""; (_) -> ", which calls" end,
     Msg = io_lib:format("The init function should return the initial state as its result and cannot ~s the state,\nbut it calls\n~s",
                         [if Which == put -> "write"; true -> "read" end,
@@ -3121,75 +3137,81 @@ mk_error({init_depends_on_state, Which, [_Init | Chain]}) ->
                            || {[_, Fun], Ann} <- Chain]]),
     mk_t_err(pos(element(2, hd(Chain))), Msg);
 mk_error({missing_body_for_let, Ann}) ->
-    Msg = io_lib:format("Let binding at ~s must be followed by an expression\n", [pp_loc(Ann)]),
+    Msg = io_lib:format("Let binding must be followed by an expression.", []),
     mk_t_err(pos(Ann), Msg);
 mk_error({public_modifier_in_contract, Decl}) ->
+    % TODO(mk_error)
     Decl1 = mk_entrypoint(Decl),
     Msg = io_lib:format("Use 'entrypoint' instead of 'function' for public function ~s (at ~s):\n~s\n",
                         [pp_expr("", element(3, Decl)), pp_loc(Decl),
                          prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({init_must_be_an_entrypoint, Decl}) ->
+    % TODO(mk_error)
     Decl1 = mk_entrypoint(Decl),
     Msg = io_lib:format("The init function (at ~s) must be an entrypoint:\n~s\n",
                         [pp_loc(Decl),
                          prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({init_must_not_be_payable, Decl}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("The init function (at ~s) cannot be payable.\n"
                         "You don't need the 'payable' annotation to be able to attach\n"
                         "funds to the create contract transaction.",
                         [pp_loc(Decl)]),
     mk_t_err(pos(Decl), Msg);
 mk_error({proto_must_be_entrypoint, Decl}) ->
+    % TODO(mk_error)
     Decl1 = mk_entrypoint(Decl),
     Msg = io_lib:format("Use 'entrypoint' for declaration of ~s (at ~s):\n~s\n",
                         [pp_expr("", element(3, Decl)), pp_loc(Decl),
                          prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({proto_in_namespace, Decl}) ->
-    Msg = io_lib:format("Namespaces cannot contain function prototypes (at ~s).\n",
-                        [pp_loc(Decl)]),
+    Msg = io_lib:format("Namespaces cannot contain function prototypes.", []),
     mk_t_err(pos(Decl), Msg);
 mk_error({entrypoint_in_namespace, Decl}) ->
-    Msg = io_lib:format("Namespaces cannot contain entrypoints (at ~s). Use 'function' instead.\n",
-                        [pp_loc(Decl)]),
+    Msg = io_lib:format("Namespaces cannot contain entrypoints. Use 'function' instead.", []),
     mk_t_err(pos(Decl), Msg);
 mk_error({private_entrypoint, Decl}) ->
-    Msg = io_lib:format("The entrypoint ~s (at ~s) cannot be private. Use 'function' instead.\n",
-                        [pp_expr("", element(3, Decl)), pp_loc(Decl)]),
+    Msg = io_lib:format("The entrypoint ~s cannot be private. Use 'function' instead.",
+                        [pp_expr("", element(3, Decl))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({private_and_public, Decl}) ->
-    Msg = io_lib:format("The function ~s (at ~s) cannot be both public and private.\n",
-                        [pp_expr("", element(3, Decl)), pp_loc(Decl)]),
+    Msg = io_lib:format("The function ~s cannot be both public and private.",
+                        [pp_expr("", element(3, Decl))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({contract_has_no_entrypoints, Con}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("The contract ~s (at ~s) has no entrypoints. Since Sophia version 3.2, public\n"
                         "contract functions must be declared with the 'entrypoint' keyword instead of\n"
                         "'function'.\n", [pp_expr("", Con), pp_loc(Con)]),
     mk_t_err(pos(Con), Msg);
 mk_error({definition_in_contract_interface, Ann, {id, _, Id}}) ->
-    Msg = "Contract interfaces cannot contain defined functions or entrypoints.\n",
-    Cxt = io_lib:format("Fix: replace the definition of '~s' by a type signature.\n", [Id]),
+    Msg = "Contract interfaces cannot contain defined functions or entrypoints.",
+    Cxt = io_lib:format("Fix: replace the definition of '~s' by a type signature.", [Id]),
     mk_t_err(pos(Ann), Msg, Cxt);
 mk_error({unbound_type, Type}) ->
-    Msg = io_lib:format("Unbound type ~s (at ~s).\n", [pp_type("", Type), pp_loc(Type)]),
+    Msg = io_lib:format("Unbound type ~s.", [pp_type("", Type)]),
     mk_t_err(pos(Type), Msg);
 mk_error({new_tuple_syntax, Ann, Ts}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Invalid type\n~s  (at ~s)\nThe syntax of tuple types changed in Sophia version 4.0. Did you mean\n~s\n",
                         [pp_type("  ", {args_t, Ann, Ts}), pp_loc(Ann), pp_type("  ", {tuple_t, Ann, Ts})]),
     mk_t_err(pos(Ann), Msg);
 mk_error({map_in_map_key, Ann, KeyType}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Invalid key type\n~s\n", [pp_type("  ", KeyType)]),
     Cxt = "Map keys cannot contain other maps.\n",
     mk_t_err(pos(Ann), Msg, Cxt);
 mk_error({cannot_call_init_function, Ann}) ->
+    % TODO(mk_error)
     Msg = "The 'init' function is called exclusively by the create contract transaction\n"
           "and cannot be called from the contract code.\n",
     mk_t_err(pos(Ann), Msg);
 mk_error({contract_treated_as_namespace, Ann, [Con, Fun] = QName}) ->
-    Msg = io_lib:format("Invalid call to contract entrypoint '~s'.\n", [string:join(QName, ".")]),
-    Cxt = io_lib:format("It must be called as 'c.~s' for some c : ~s.\n", [Fun, Con]),
+    Msg = io_lib:format("Invalid call to contract entrypoint '~s'.", [string:join(QName, ".")]),
+    Cxt = io_lib:format("It must be called as 'c.~s' for some c : ~s.", [Fun, Con]),
     mk_t_err(pos(Ann), Msg, Cxt);
 mk_error({bad_top_level_decl, Decl}) ->
     What = case element(1, Decl) of
@@ -3197,64 +3219,73 @@ mk_error({bad_top_level_decl, Decl}) ->
                _      -> "contract or namespace"
            end,
     Id = element(3, Decl),
-    Msg = io_lib:format("The definition of '~s' must appear inside a ~s.\n",
+    Msg = io_lib:format("The definition of '~s' must appear inside a ~s.",
                         [pp_expr("", Id), What]),
     mk_t_err(pos(Decl), Msg);
 mk_error({unknown_byte_length, Type}) ->
-    Msg = io_lib:format("Cannot resolve length of byte array.\n", []),
+    Msg = io_lib:format("Cannot resolve length of byte array.", []),
     mk_t_err(pos(Type), Msg);
 mk_error({unsolved_bytes_constraint, Ann, concat, A, B, C}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Failed to resolve byte array lengths in call to Bytes.concat with arguments of type\n"
                         "~s  (at ~s)\n~s  (at ~s)\nand result type\n~s  (at ~s)\n",
                         [pp_type("  - ", A), pp_loc(A), pp_type("  - ", B),
                          pp_loc(B), pp_type("  - ", C), pp_loc(C)]),
     mk_t_err(pos(Ann), Msg);
 mk_error({unsolved_bytes_constraint, Ann, split, A, B, C}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Failed to resolve byte array lengths in call to Bytes.split with argument of type\n"
                         "~s  (at ~s)\nand result types\n~s  (at ~s)\n~s  (at ~s)\n",
                         [ pp_type("  - ", C), pp_loc(C), pp_type("  - ", A), pp_loc(A),
                           pp_type("  - ", B), pp_loc(B)]),
     mk_t_err(pos(Ann), Msg);
 mk_error({failed_to_get_compiler_version, Err}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Failed to get compiler version. Error:\n  ~p\n", [Err]),
     mk_t_err(pos(0, 0), Msg);
 mk_error({compiler_version_mismatch, Ann, Version, Op, Bound}) ->
+    % TODO(mk_error)
     PrintV = fun(V) -> string:join([integer_to_list(N) || N <- V], ".") end,
     Msg = io_lib:format("Cannot compile with this version of the compiler,\n"
                         "because it does not satisfy the constraint"
                         " ~s ~s ~s\n", [PrintV(Version), Op, PrintV(Bound)]),
     mk_t_err(pos(Ann), Msg);
 mk_error({empty_record_or_map_update, Expr}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Empty record/map update\n~s",
                         [pp_expr("  ", Expr)]),
     mk_t_err(pos(Expr), Msg);
 mk_error({mixed_record_and_map, Expr}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Mixed record fields and map keys in\n~s",
                         [pp_expr("  ", Expr)]),
     mk_t_err(pos(Expr), Msg);
 mk_error({named_argument_must_be_literal_bool, Name, Arg}) ->
+    % TODO(mk_error)
     Msg = io_lib:format("Invalid '~s' argument\n~s\nIt must be either 'true' or 'false'.", [Name, pp_expr("  ", instantiate(Arg))]),
     mk_t_err(pos(Arg), Msg);
 mk_error({conflicting_updates_for_field, Upd, Key}) ->
-    Msg = io_lib:format("Conflicting updates for field '~s'\n", [Key]),
+    Msg = io_lib:format("Conflicting updates for field '~s'", [Key]),
     mk_t_err(pos(Upd), Msg);
 mk_error({ambiguous_main_contract, Ann}) ->
     Msg = "Could not deduce the main contract. You can point it out manually with the `main` keyword.",
     mk_t_err(pos(Ann), Msg);
 mk_error({main_contract_undefined, Ann}) ->
-    Msg = "No contract defined.\n",
+    Msg = "No contract defined.",
     mk_t_err(pos(Ann), Msg);
 mk_error({multiple_main_contracts, Ann}) ->
-    Msg = "Only one main contract can be defined.\n",
+    Msg = "Only one main contract can be defined.",
     mk_t_err(pos(Ann), Msg);
 mk_error({unify_varargs, When}) ->
+    % TODO(mk_error)
     Msg = "Cannot unify variable argument list.\n",
     {Pos, Ctxt} = pp_when(When),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({clone_no_contract, Ann}) ->
-    Msg = "Chain.clone requires `ref` named argument of contract type.\n",
+    Msg = "Chain.clone requires `ref` named argument of contract type.",
     mk_t_err(pos(Ann), Msg);
 mk_error({contract_lacks_definition, Type, When}) ->
+    % TODO(mk_error)
     Msg = io_lib:format(
             "~s is not implemented.\n",
             [pp_type(Type)]
@@ -3262,6 +3293,7 @@ mk_error({contract_lacks_definition, Type, When}) ->
     {Pos, Ctxt} = pp_when(When),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({ambiguous_name, QIds = [{qid, Ann, _} | _]}) ->
+    % TODO(mk_error)
     Names = lists:map(fun(QId) -> io_lib:format("~s at ~s\n", [pp(QId), pp_loc(QId)]) end, QIds),
     Msg = "Ambiguous name: " ++ lists:concat(Names),
     mk_t_err(pos(Ann), Msg);
@@ -3276,7 +3308,7 @@ mk_error({unknown_warning, Warning}) ->
     Msg = io_lib:format("Trying to report unknown warning: ~p", [Warning]),
     mk_t_err(pos(0, 0), Msg);
 mk_error(Err) ->
-    Msg = io_lib:format("Unknown error: ~p\n", [Err]),
+    Msg = io_lib:format("Unknown error: ~p", [Err]),
     mk_t_err(pos(0, 0), Msg).
 
 mk_warning({unused_include, FileName, SrcFile}) ->

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -2074,6 +2074,12 @@ get_option(Key, Default) ->
 when_option(Opt, Do) ->
     get_option(Opt, false) andalso Do().
 
+when_option_else(Opt, Do, Else) ->
+    case get_option(Opt, false) of
+        true -> Do();
+        _    -> Else()
+    end.
+
 %% -- Constraints --
 
 create_constraints() ->
@@ -2951,8 +2957,11 @@ mk_error({wrong_type_arguments, X, ArityGiven, ArityReal}) ->
                        ),
     mk_t_err(pos(X), Msg);
 mk_error({unnamed_map_update_with_default, Upd}) ->
-    Msg = "Invalid map update with default\n",
-    mk_t_err(pos(Upd), Msg);
+    MsgRaw = "Invalid map update with default",
+    Msg = MsgRaw ++ "\n",
+    when_option_else(raw_error_messages,
+                     fun() -> mk_t_err(pos(Upd), MsgRaw) end,
+                     fun() -> mk_t_err(pos(Upd), Msg) end);
 mk_error({fundecl_must_have_funtype, _Ann, Id, Type}) ->
     Msg = io_lib:format("~s at ~s was declared with an invalid type ~s.\n"
                        "Entrypoints and functions must have functional types"
@@ -2964,12 +2973,17 @@ mk_error({cannot_unify, A, B, When}) ->
     {Pos, Ctxt} = pp_when(When),
     mk_t_err(Pos, Msg, Ctxt);
 mk_error({unbound_variable, Id}) ->
+    MsgRaw = io_lib:format("Unbound variable ~s", [pp(Id)]),
     Msg = io_lib:format("Unbound variable ~s at ~s\n", [pp(Id), pp_loc(Id)]),
     case Id of
         {qid, _, ["Chain", "event"]} ->
             Cxt = "Did you forget to define the event type?",
-            mk_t_err(pos(Id), Msg, Cxt);
-        _ -> mk_t_err(pos(Id), Msg)
+            when_option_else(raw_error_messages,
+                             fun() -> mk_t_err(pos(Id), MsgRaw, Cxt) end,
+                             fun() -> mk_t_err(pos(Id), Msg, Cxt) end);
+        _ -> when_option_else(raw_error_messages,
+                              fun() -> mk_t_err(pos(Id), MsgRaw) end,
+                              fun() -> mk_t_err(pos(Id), Msg) end)
     end;
 mk_error({undefined_field, Id}) ->
     Msg = io_lib:format("Unbound field ~s at ~s\n", [pp(Id), pp_loc(Id)]),

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -3131,18 +3131,15 @@ mk_error({missing_body_for_let, Ann}) ->
     Msg = io_lib:format("Let binding must be followed by an expression.", []),
     mk_t_err(pos(Ann), Msg);
 mk_error({public_modifier_in_contract, Decl}) ->
-    % TODO(mk_error)
     Decl1 = mk_entrypoint(Decl),
-    Msg = io_lib:format("Use 'entrypoint' instead of 'function' for public function ~s (at ~s):\n~s\n",
-                        [pp_expr("", element(3, Decl)), pp_loc(Decl),
+    Msg = io_lib:format("Use 'entrypoint' instead of 'function' for public function `~s`: `~s`",
+                        [pp_expr(element(3, Decl)),
                          prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({init_must_be_an_entrypoint, Decl}) ->
-    % TODO(mk_error)
     Decl1 = mk_entrypoint(Decl),
-    Msg = io_lib:format("The init function (at ~s) must be an entrypoint:\n~s\n",
-                        [pp_loc(Decl),
-                         prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
+    Msg = io_lib:format("The init function must be an entrypoint: ~s",
+                        [prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({init_must_not_be_payable, Decl}) ->
     Msg = io_lib:format("The init function cannot be payable. "
@@ -3151,10 +3148,9 @@ mk_error({init_must_not_be_payable, Decl}) ->
                         []),
     mk_t_err(pos(Decl), Msg);
 mk_error({proto_must_be_entrypoint, Decl}) ->
-    % TODO(mk_error)
     Decl1 = mk_entrypoint(Decl),
-    Msg = io_lib:format("Use 'entrypoint' for declaration of ~s (at ~s):\n~s\n",
-                        [pp_expr("", element(3, Decl)), pp_loc(Decl),
+    Msg = io_lib:format("Use 'entrypoint' for declaration of `~s`: `~s`",
+                        [pp_expr(element(3, Decl)),
                          prettypr:format(prettypr:nest(2, aeso_pretty:decl(Decl1)))]),
     mk_t_err(pos(Decl), Msg);
 mk_error({proto_in_namespace, Decl}) ->
@@ -3184,14 +3180,12 @@ mk_error({unbound_type, Type}) ->
     Msg = io_lib:format("Unbound type ~s.", [pp_type("", Type)]),
     mk_t_err(pos(Type), Msg);
 mk_error({new_tuple_syntax, Ann, Ts}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Invalid type\n~s  (at ~s)\nThe syntax of tuple types changed in Sophia version 4.0. Did you mean\n~s\n",
-                        [pp_type("  ", {args_t, Ann, Ts}), pp_loc(Ann), pp_type("  ", {tuple_t, Ann, Ts})]),
+    Msg = io_lib:format("Invalid type `~s`. The syntax of tuple types changed in Sophia version 4.0. Did you mean `~s`",
+                        [pp_type({args_t, Ann, Ts}), pp_type({tuple_t, Ann, Ts})]),
     mk_t_err(pos(Ann), Msg);
 mk_error({map_in_map_key, Ann, KeyType}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Invalid key type\n~s\n", [pp_type("  ", KeyType)]),
-    Cxt = "Map keys cannot contain other maps.\n",
+    Msg = io_lib:format("Invalid key type:~s", [pp_type(" ", KeyType)]),
+    Cxt = "Map keys cannot contain other maps.",
     mk_t_err(pos(Ann), Msg, Cxt);
 mk_error({cannot_call_init_function, Ann}) ->
     Msg = "The 'init' function is called exclusively by the create contract transaction "
@@ -3228,29 +3222,22 @@ mk_error({unsolved_bytes_constraint, Ann, split, A, B, C}) ->
                           pp_type("  - ", B), pp_loc(B)]),
     mk_t_err(pos(Ann), Msg);
 mk_error({failed_to_get_compiler_version, Err}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Failed to get compiler version. Error:\n  ~p\n", [Err]),
+    Msg = io_lib:format("Failed to get compiler version. Error: ~p", [Err]),
     mk_t_err(pos(0, 0), Msg);
 mk_error({compiler_version_mismatch, Ann, Version, Op, Bound}) ->
-    % TODO(mk_error)
     PrintV = fun(V) -> string:join([integer_to_list(N) || N <- V], ".") end,
-    Msg = io_lib:format("Cannot compile with this version of the compiler,\n"
+    Msg = io_lib:format("Cannot compile with this version of the compiler, "
                         "because it does not satisfy the constraint"
-                        " ~s ~s ~s\n", [PrintV(Version), Op, PrintV(Bound)]),
+                        " ~s ~s ~s", [PrintV(Version), Op, PrintV(Bound)]),
     mk_t_err(pos(Ann), Msg);
 mk_error({empty_record_or_map_update, Expr}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Empty record/map update\n~s",
-                        [pp_expr("  ", Expr)]),
+    Msg = io_lib:format("Empty record/map update `~s`", [pp_expr(Expr)]),
     mk_t_err(pos(Expr), Msg);
 mk_error({mixed_record_and_map, Expr}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Mixed record fields and map keys in\n~s",
-                        [pp_expr("  ", Expr)]),
+    Msg = io_lib:format("Mixed record fields and map keys in `~s`", [pp_expr(Expr)]),
     mk_t_err(pos(Expr), Msg);
 mk_error({named_argument_must_be_literal_bool, Name, Arg}) ->
-    % TODO(mk_error)
-    Msg = io_lib:format("Invalid '~s' argument\n~s\nIt must be either 'true' or 'false'.", [Name, pp_expr("  ", instantiate(Arg))]),
+    Msg = io_lib:format("Invalid '~s' argument `~s` It must be either 'true' or 'false'.", [Name, pp_expr(instantiate(Arg))]),
     mk_t_err(pos(Arg), Msg);
 mk_error({conflicting_updates_for_field, Upd, Key}) ->
     Msg = io_lib:format("Conflicting updates for field '~s'", [Key]),

--- a/src/aeso_code_errors.erl
+++ b/src/aeso_code_errors.erl
@@ -11,21 +11,21 @@
 -export([format/1, pos/1]).
 
 format({last_declaration_must_be_main_contract, Decl = {Kind, _, {con, _, C}, _}}) ->
-    Msg = io_lib:format("Expected a main contract as the last declaration instead of the ~p '~s'\n",
+    Msg = io_lib:format("Expected a main contract as the last declaration instead of the ~p '~s'",
                         [Kind, C]),
     mk_err(pos(Decl), Msg);
 format({missing_init_function, Con}) ->
-    Msg = io_lib:format("Missing init function for the contract '~s'.\n", [pp_expr(Con)]),
-    Cxt = "The 'init' function can only be omitted if the state type is 'unit'.\n",
+    Msg = io_lib:format("Missing init function for the contract '~s'.", [pp_expr(Con)]),
+    Cxt = "The 'init' function can only be omitted if the state type is 'unit'.",
     mk_err(pos(Con), Msg, Cxt);
 format({missing_definition, Id}) ->
-    Msg = io_lib:format("Missing definition of function '~s'.\n", [pp_expr(Id)]),
+    Msg = io_lib:format("Missing definition of function '~s'.", [pp_expr(Id)]),
     mk_err(pos(Id), Msg);
 format({parameterized_state, Decl}) ->
-    Msg = "The state type cannot be parameterized.\n",
+    Msg = "The state type cannot be parameterized.",
     mk_err(pos(Decl), Msg);
 format({parameterized_event, Decl}) ->
-    Msg = "The event type cannot be parameterized.\n",
+    Msg = "The event type cannot be parameterized.",
     mk_err(pos(Decl), Msg);
 format({invalid_entrypoint, Why, Ann, {id, _, Name}, Thing}) ->
     What = case Why of higher_order -> "higher-order (contains function types)";
@@ -38,54 +38,54 @@ format({invalid_entrypoint, Why, Ann, {id, _, Name}, Thing}) ->
               {argument, _, _} -> io_lib:format("has a ~s type", [What]);
               {result, _}      -> io_lib:format("is ~s", [What])
           end,
-    Msg = io_lib:format("The ~sof entrypoint '~s' ~s.\n",
+    Msg = io_lib:format("The ~sof entrypoint '~s' ~s.",
                         [ThingS, Name, Bad]),
     case Why of
         polymorphic  -> mk_err(pos(Ann), Msg, "Use the FATE backend if you want polymorphic entrypoints.\n");
         higher_order -> mk_err(pos(Ann), Msg)
     end;
 format({cant_compare_type_aevm, Ann, Op, Type}) ->
-    StringAndTuple = [ "- type string\n"
-                       "- tuple or record of word type\n" || lists:member(Op, ['==', '!=']) ],
+    StringAndTuple = [ "\n- type string"
+                       "\n- tuple or record of word type" || lists:member(Op, ['==', '!=']) ],
     Msg = io_lib:format("Cannot compare values of type\n"
                         "~s\n"
                         "The AEVM only supports '~s' on values of\n"
-                        "- word type (int, bool, bits, address, oracle(_, _), etc)\n"
+                        "- word type (int, bool, bits, address, oracle(_, _), etc)"
                         "~s",
                         [pp_type(2, Type), Op, StringAndTuple]),
-    Cxt = "Use FATE if you need to compare arbitrary types.\n",
+    Cxt = "Use FATE if you need to compare arbitrary types.",
     mk_err(pos(Ann), Msg, Cxt);
 format({invalid_aens_resolve_type, Ann, T}) ->
     Msg = io_lib:format("Invalid return type of AENS.resolve:\n"
                         "~s\n"
-                        "It must be a string or a pubkey type (address, oracle, etc).\n",
+                        "It must be a string or a pubkey type (address, oracle, etc).",
                         [pp_type(2, T)]),
     mk_err(pos(Ann), Msg);
 format({unapplied_contract_call, Contract}) ->
     Msg = io_lib:format("The AEVM does not support unapplied contract call to\n"
-                        "~s\n", [pp_expr(2, Contract)]),
-    Cxt = "Use FATE if you need this.\n",
+                        "~s", [pp_expr(2, Contract)]),
+    Cxt = "Use FATE if you need this.",
     mk_err(pos(Contract), Msg, Cxt);
 format({unapplied_builtin, Id}) ->
-    Msg = io_lib:format("The AEVM does not support unapplied use of ~s.\n", [pp_expr(0, Id)]),
-    Cxt = "Use FATE if you need this.\n",
+    Msg = io_lib:format("The AEVM does not support unapplied use of ~s.", [pp_expr(0, Id)]),
+    Cxt = "Use FATE if you need this.",
     mk_err(pos(Id), Msg, Cxt);
 format({invalid_map_key_type, Why, Ann, Type}) ->
-    Msg = io_lib:format("Invalid map key type\n~s\n", [pp_type(2, Type)]),
+    Msg = io_lib:format("Invalid map key type\n~s", [pp_type(2, Type)]),
     Cxt = case Why of
-             polymorphic -> "Map keys cannot be polymorphic in the AEVM. Use FATE if you need this.\n";
-             function    -> "Map keys cannot be higher-order.\n"
+             polymorphic -> "Map keys cannot be polymorphic in the AEVM. Use FATE if you need this.";
+             function    -> "Map keys cannot be higher-order."
           end,
     mk_err(pos(Ann), Msg, Cxt);
 format({invalid_oracle_type, Why, What, Ann, Type}) ->
     WhyS = case Why of higher_order -> "higher-order (contain function types)";
                        polymorphic  -> "polymorphic (contain type variables)" end,
-    Msg = io_lib:format("Invalid oracle type\n~s\n", [pp_type(2, Type)]),
-    Cxt = io_lib:format("The ~s type must not be ~s.\n", [What, WhyS]),
+    Msg = io_lib:format("Invalid oracle type\n~s", [pp_type(2, Type)]),
+    Cxt = io_lib:format("The ~s type must not be ~s.", [What, WhyS]),
     mk_err(pos(Ann), Msg, Cxt);
 format({higher_order_state, {type_def, Ann, _, _, State}}) ->
-    Msg = io_lib:format("Invalid state type\n~s\n", [pp_type(2, State)]),
-    Cxt = "The state cannot contain functions in the AEVM. Use FATE if you need this.\n",
+    Msg = io_lib:format("Invalid state type\n~s", [pp_type(2, State)]),
+    Cxt = "The state cannot contain functions in the AEVM. Use FATE if you need this.",
     mk_err(pos(Ann), Msg, Cxt);
 format({var_args_not_set, Expr}) ->
     mk_err( pos(Expr), "Could not deduce type of variable arguments list"

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -325,14 +325,14 @@ to_sophia_value(_, _, revert, Data, Options) ->
                 {ok, Err} ->
                     {ok, {app, [], {id, [], "abort"}, [{string, [], Err}]}};
                 {error, _} ->
-                    Msg = "Could not interpret the revert message\n",
+                    Msg = "Could not interpret the revert message",
                     {error, [aeso_errors:new(data_error, Msg)]}
             end;
         fate ->
             try aeb_fate_encoding:deserialize(Data) of
                 Err -> {ok, {app, [], {id, [], "abort"}, [{string, [], Err}]}}
             catch _:_ ->
-                Msg = "Could not deserialize the revert message\n",
+                Msg = "Could not deserialize the revert message",
                 {error, [aeso_errors:new(data_error, Msg)]}
             end
     end;
@@ -354,12 +354,12 @@ to_sophia_value(ContractString, FunName, ok, Data, Options0) ->
                             {ok, aeso_vm_decode:from_aevm(VmType, Type, VmValue)}
                         catch throw:cannot_translate_to_sophia ->
                             Type0Str = prettypr:format(aeso_pretty:type(Type0)),
-                            Msg = io_lib:format("Cannot translate VM value ~p\n  of type ~p\n  to Sophia type ~s\n",
+                            Msg = io_lib:format("Cannot translate VM value ~p\n  of type ~p\n  to Sophia type ~s",
                                                 [Data, VmType, Type0Str]),
                             {error, [aeso_errors:new(data_error, Msg)]}
                         end;
                     {error, _Err} ->
-                        Msg = io_lib:format("Failed to decode binary as type ~p\n", [VmType]),
+                        Msg = io_lib:format("Failed to decode binary as type ~p", [VmType]),
                         {error, [aeso_errors:new(data_error, Msg)]}
                 end;
             fate ->
@@ -367,12 +367,12 @@ to_sophia_value(ContractString, FunName, ok, Data, Options0) ->
                     {ok, aeso_vm_decode:from_fate(Type, aeb_fate_encoding:deserialize(Data))}
                 catch throw:cannot_translate_to_sophia ->
                         Type1 = prettypr:format(aeso_pretty:type(Type0)),
-                        Msg = io_lib:format("Cannot translate FATE value ~p\n  of Sophia type ~s\n",
+                        Msg = io_lib:format("Cannot translate FATE value ~p\n  of Sophia type ~s",
                                             [aeb_fate_encoding:deserialize(Data), Type1]),
                         {error, [aeso_errors:new(data_error, Msg)]};
                       _:_ ->
                         Type1 = prettypr:format(aeso_pretty:type(Type0)),
-                        Msg = io_lib:format("Failed to decode binary as type ~s\n", [Type1]),
+                        Msg = io_lib:format("Failed to decode binary as type ~s", [Type1]),
                         {error, [aeso_errors:new(data_error, Msg)]}
                end
         end
@@ -436,12 +436,12 @@ decode_calldata(ContractString, FunName, Calldata, Options0) ->
                             {ok, ArgTypes, Values}
                         catch throw:cannot_translate_to_sophia ->
                             Type0Str = prettypr:format(aeso_pretty:type(Type0)),
-                            Msg = io_lib:format("Cannot translate VM value ~p\n  of type ~p\n  to Sophia type ~s\n",
+                            Msg = io_lib:format("Cannot translate VM value ~p\n  of type ~p\n  to Sophia type ~s",
                                                 [VmValue, VmType, Type0Str]),
                             {error, [aeso_errors:new(data_error, Msg)]}
                         end;
                     {error, _Err} ->
-                        Msg = io_lib:format("Failed to decode calldata as type ~p\n", [VmType]),
+                        Msg = io_lib:format("Failed to decode calldata as type ~p", [VmType]),
                         {error, [aeso_errors:new(data_error, Msg)]}
                 end;
             fate ->
@@ -454,12 +454,12 @@ decode_calldata(ContractString, FunName, Calldata, Options0) ->
                             {ok, ArgTypes, AstArgs}
                         catch throw:cannot_translate_to_sophia ->
                                 Type0Str = prettypr:format(aeso_pretty:type(Type0)),
-                                Msg = io_lib:format("Cannot translate FATE value ~p\n  to Sophia type ~s\n",
+                                Msg = io_lib:format("Cannot translate FATE value ~p\n  to Sophia type ~s",
                                                     [FateArgs, Type0Str]),
                                 {error, [aeso_errors:new(data_error, Msg)]}
                         end;
                     {error, _} ->
-                        Msg = io_lib:format("Failed to decode calldata binary\n", []),
+                        Msg = io_lib:format("Failed to decode calldata binary", []),
                         {error, [aeso_errors:new(data_error, Msg)]}
                 end
         end
@@ -502,7 +502,7 @@ get_decode_type(FunName, [{Contract, Ann, _, Defs}]) when ?IS_CONTRACT_HEAD(Cont
             case FunName of
                 "init" -> {ok, [], {tuple_t, [], []}};
                  _ ->
-                    Msg = io_lib:format("Function '~s' is missing in contract\n", [FunName]),
+                    Msg = io_lib:format("Function '~s' is missing in contract", [FunName]),
                     Pos = aeso_code_errors:pos(Ann),
                     aeso_errors:throw(aeso_errors:new(data_error, Pos, Msg))
             end

--- a/src/aeso_errors.erl
+++ b/src/aeso_errors.erl
@@ -66,7 +66,7 @@ throw(#err{} = Err) ->
     erlang:throw({error, [Err]}).
 
 msg(#err{ message = Msg, context = none }) -> Msg;
-msg(#err{ message = Msg, context = Ctxt }) -> Msg ++ Ctxt.
+msg(#err{ message = Msg, context = Ctxt }) -> Msg ++ "\n" ++ Ctxt.
 
 err_msg(#err{ pos = Pos } = Err) ->
     lists:flatten(io_lib:format("~s~s", [str_pos(Pos), msg(Err)])).

--- a/src/aeso_errors.erl
+++ b/src/aeso_errors.erl
@@ -69,7 +69,7 @@ msg(#err{ message = Msg, context = none }) -> Msg;
 msg(#err{ message = Msg, context = Ctxt }) -> Msg ++ "\n" ++ Ctxt.
 
 err_msg(#err{ pos = Pos } = Err) ->
-    lists:flatten(io_lib:format("~s~s", [str_pos(Pos), msg(Err)])).
+    lists:flatten(io_lib:format("~s~s\n", [str_pos(Pos), msg(Err)])).
 
 str_pos(#pos{file = no_file, line = L, col = C}) ->
     io_lib:format("~p:~p:", [L, C]);
@@ -79,7 +79,7 @@ str_pos(#pos{file = F, line = L, col = C}) ->
 type(#err{ type = Type }) -> Type.
 
 pp(#err{ type = Kind, pos = Pos } = Err) ->
-    lists:flatten(io_lib:format("~s~s:\n~s", [pp_kind(Kind), pp_pos(Pos), msg(Err)])).
+    lists:flatten(io_lib:format("~s~s:\n~s\n", [pp_kind(Kind), pp_pos(Pos), msg(Err)])).
 
 pp_kind(type_error)     -> "Type error";
 pp_kind(parse_error)    -> "Parse error";

--- a/test/aeso_abi_tests.erl
+++ b/test/aeso_abi_tests.erl
@@ -95,7 +95,7 @@ encode_calldata_neg_test() ->
               "when checking the application of\n"
               "  `x : (int) => string`\n"
               "to arguments\n"
-              "  `true : bool`",
+              "  `true : bool`\n",
     {error, [Err1]} = aeso_compiler:create_calldata(Code, "x", ["true"]),
     ?assertEqual(ExpErr1, aeso_errors:pp(Err1)),
     {error, [Err2]} = aeso_compiler:create_calldata(Code, "x", ["true"], [{backend, fate}]),

--- a/test/aeso_abi_tests.erl
+++ b/test/aeso_abi_tests.erl
@@ -91,9 +91,11 @@ encode_calldata_neg_test() ->
     Code = [ "contract Foo =\n"
              "  entrypoint x(y : int) : string = \"hello\"\n" ],
 
-    ExpErr1 = "Type error at line 5, col 34:\nCannot unify int\n         and bool\n"
-              "when checking the application at line 5, column 34 of\n"
-              "  x : (int) => string\nto arguments\n  true : bool\n",
+    ExpErr1 = "Type error at line 5, col 34:\nCannot unify `int` and `bool`\n"
+              "when checking the application of\n"
+              "  `x : (int) => string`\n"
+              "to arguments\n"
+              "  `true : bool`",
     {error, [Err1]} = aeso_compiler:create_calldata(Code, "x", ["true"]),
     ?assertEqual(ExpErr1, aeso_errors:pp(Err1)),
     {error, [Err2]} = aeso_compiler:create_calldata(Code, "x", ["true"], [{backend, fate}]),

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -257,33 +257,33 @@ debug_mode_contracts() ->
 warnings() ->
     ?WARNING(warnings,
      [<<?PosW(0, 0)
-        "The file Triple.aes is included but not used">>,
+        "The file `Triple.aes` is included but not used.">>,
       <<?PosW(13, 3)
-        "The function h is defined at line 13, column 3 but never used">>,
+        "The function `h` is defined but never used.">>,
       <<?PosW(19, 3)
-        "The type unused_type is defined at line 19, column 3 but never used">>,
+        "The type `unused_type` is defined but never used.">>,
       <<?PosW(23, 54)
-        "Negative spend at line 23, column 54">>,
+        "Negative spend.">>,
       <<?PosW(27, 9)
-        "The definition of x at line 27, column 9 shadows an older definition at line 26, column 9">>,
+        "The definition of `x` shadows an older definition at line 26, column 9.">>,
       <<?PosW(30, 36)
-        "Division by zero at line 30, column 36">>,
+        "Division by zero.">>,
       <<?PosW(32, 3)
-        "The function unused_stateful is unnecessarily marked as stateful at line 32, column 3">>,
+        "The function `unused_stateful` is unnecessarily marked as stateful.">>,
       <<?PosW(35, 31)
-        "The variable unused_arg is defined at line 35, column 31 but never used">>,
+        "The variable `unused_arg` is defined but never used.">>,
       <<?PosW(36, 9)
-        "The variable unused_var is defined at line 36, column 9 but never used">>,
+        "The variable `unused_var` is defined but never used.">>,
       <<?PosW(41, 3)
-        "The function unused_function is defined at line 41, column 3 but never used">>,
+        "The function `unused_function` is defined but never used.">>,
       <<?PosW(42, 3)
-        "The function recursive_unused_function is defined at line 42, column 3 but never used">>,
+        "The function `recursive_unused_function` is defined but never used.">>,
       <<?PosW(43, 3)
-        "The function called_unused_function1 is defined at line 43, column 3 but never used">>,
+        "The function `called_unused_function1` is defined but never used.">>,
       <<?PosW(44, 3)
-        "The function called_unused_function2 is defined at line 44, column 3 but never used">>,
+        "The function `called_unused_function2` is defined but never used.">>,
       <<?PosW(48, 5)
-        "Unused return value at line 48, column 5">>
+        "Unused return value.">>
      ]).
 
 failing_contracts() ->
@@ -301,82 +301,65 @@ failing_contracts() ->
     %% Type errors
     , ?TYPE_ERROR(name_clash,
        [<<?Pos(14, 3)
-          "Duplicate definitions of abort at\n"
+          "Duplicate definitions of `abort` at\n"
           "  - (builtin location)\n"
           "  - line 14, column 3">>,
         <<?Pos(15, 3)
-          "Duplicate definitions of require at\n"
+          "Duplicate definitions of `require` at\n"
           "  - (builtin location)\n"
           "  - line 15, column 3">>,
         <<?Pos(11, 3)
-          "Duplicate definitions of double_def at\n"
+          "Duplicate definitions of `double_def` at\n"
           "  - line 10, column 3\n"
           "  - line 11, column 3">>,
         <<?Pos(5, 3)
-          "Duplicate definitions of double_proto at\n"
+          "Duplicate definitions of `double_proto` at\n"
           "  - line 4, column 3\n"
           "  - line 5, column 3">>,
         <<?Pos(8, 3)
-          "Duplicate definitions of proto_and_def at\n"
+          "Duplicate definitions of `proto_and_def` at\n"
           "  - line 7, column 3\n"
           "  - line 8, column 3">>,
         <<?Pos(16, 3)
-          "Duplicate definitions of put at\n"
+          "Duplicate definitions of `put` at\n"
           "  - (builtin location)\n"
           "  - line 16, column 3">>,
         <<?Pos(17, 3)
-          "Duplicate definitions of state at\n"
+          "Duplicate definitions of `state` at\n"
           "  - (builtin location)\n"
           "  - line 17, column 3">>])
     , ?TYPE_ERROR(type_errors,
        [<<?Pos(17, 23)
           "Unbound variable `zz`">>,
         <<?Pos(26, 9)
-          "Cannot unify int\n"
-          "         and list(int)\n"
-          "when checking the application at line 26, column 9 of\n"
-          "  (::) : (int, list(int)) => list(int)\n"
+          "Cannot unify `int` and `list(int)`\n"
+          "when checking the application of\n"
+          "  `(::) : (int, list(int)) => list(int)`\n"
           "to arguments\n"
-          "  x : int\n"
-          "  x : int">>,
+          "  `x : int`\n"
+          "  `x : int`">>,
         <<?Pos(9, 48)
-          "Cannot unify string\n"
-          "         and int\n"
-          "when checking the assignment of the field\n"
-          "  x : map(string, string) (at line 9, column 48)\n"
-          "to the old value __x and the new value\n"
-          "  __x {[\"foo\"] @ x = x + 1} : map(string, int)">>,
+          "Cannot unify `string` and `int`\n"
+          "when checking the assignment of the field `x : map(string, string)` "
+          "to the old value `__x` and the new value `__x {[\"foo\"] @ x = x + 1} : map(string, int)`">>,
         <<?Pos(34, 47)
-          "Cannot unify int\n"
-          "         and string\n"
-          "when checking the type of the expression at line 34, column 47\n"
-          "  1 : int\n"
-          "against the expected type\n"
-          "  string">>,
+          "Cannot unify `int` and `string`\n"
+          "when checking the type of the expression `1 : int` "
+          "against the expected type `string`">>,
         <<?Pos(34, 52)
-          "Cannot unify string\n"
-          "         and int\n"
-          "when checking the type of the expression at line 34, column 52\n"
-          "  \"bla\" : string\n"
-          "against the expected type\n"
-          "  int">>,
+          "Cannot unify `string` and `int`\n"
+          "when checking the type of the expression `\"bla\" : string` "
+          "against the expected type `int`">>,
         <<?Pos(32, 18)
-          "Cannot unify string\n"
-          "         and int\n"
-          "when checking the type of the expression at line 32, column 18\n"
-          "  \"x\" : string\n"
-          "against the expected type\n"
-          "  int">>,
+          "Cannot unify `string` and `int`\n"
+          "when checking the type of the expression `\"x\" : string` "
+          "against the expected type `int`">>,
         <<?Pos(11, 58)
-          "Cannot unify string\n"
-          "         and int\n"
-          "when checking the type of the expression at line 11, column 58\n"
-          "  \"foo\" : string\n"
-          "against the expected type\n"
-          "  int">>,
+          "Cannot unify `string` and `int`\n"
+          "when checking the type of the expression `\"foo\" : string` "
+          "against the expected type `int`">>,
         <<?Pos(38, 13)
-          "Cannot unify int\n"
-          "         and string\n"
+          "Cannot unify `int` and `string`\n"
           "when comparing the types of the if-branches\n"
           "  - w : int (at line 38, column 13)\n"
           "  - z : string (at line 39, column 10)">>,
@@ -393,27 +376,21 @@ failing_contracts() ->
           "Not a record type: `string`\n"
           "arising from an assignment of the field `y`">>,
         <<?Pos(13, 27)
-          "Ambiguous record type with field y (at line 13, column 27) could be one of\n"
-          "  - r (at line 4, column 10)\n"
-          "  - r' (at line 5, column 10)">>,
+          "Ambiguous record type with field `y` could be one of\n"
+          "  - `r` (at line 4, column 10)\n"
+          "  - `r'` (at line 5, column 10)">>,
         <<?Pos(26, 7)
           "Repeated name `x` in the pattern `x :: x`">>,
         <<?Pos(44, 14)
           "Repeated names `x`, `y` in the pattern `(x : int, y, x : string, y : bool)`">>,
         <<?Pos(44, 39)
-          "Cannot unify int\n"
-          "         and string\n"
-          "when checking the type of the expression at line 44, column 39\n"
-          "  x : int\n"
-          "against the expected type\n"
-          "  string">>,
+          "Cannot unify `int` and `string`\n"
+          "when checking the type of the expression `x : int` "
+          "against the expected type `string`">>,
         <<?Pos(44, 72)
-          "Cannot unify int\n"
-          "         and string\n"
-          "when checking the type of the expression at line 44, column 72\n"
-          "  x : int\n"
-          "against the expected type\n"
-          "  string">>,
+          "Cannot unify `int` and `string`\n"
+          "when checking the type of the expression `x : int` "
+          "against the expected type `string`">>,
         <<?Pos(14, 24)
           "No record type with fields `y`, `z`">>,
         <<?Pos(15, 26)
@@ -429,22 +406,17 @@ failing_contracts() ->
         <<?Pos(58, 5)
           "Let binding must be followed by an expression.">>,
         <<?Pos(63, 5)
-          "Cannot unify int\n"
-          "         and bool\n"
-          "when checking the type of the expression at line 63, column 5\n"
-          "  id(n) : int\n"
-          "against the expected type\n"
-          "  bool">>])
+          "Cannot unify `int` and `bool`\n"
+          "when checking the type of the expression `id(n) : int` "
+          "against the expected type `bool`">>])
     , ?TYPE_ERROR(init_type_error,
        [<<?Pos(7, 3)
-          "Cannot unify string\n"
-          "         and map(int, int)\n"
-          "when checking that 'init' returns a value of type 'state' at line 7, column 3">>])
+          "Cannot unify `string` and `map(int, int)`\n"
+          "when checking that `init` returns a value of type `state`">>])
     , ?TYPE_ERROR(missing_state_type,
        [<<?Pos(5, 3)
-          "Cannot unify string\n"
-          "         and unit\n"
-          "when checking that 'init' returns a value of type 'state' at line 5, column 3">>])
+          "Cannot unify `string` and `unit`\n"
+          "when checking that `init` returns a value of type `state`">>])
     , ?TYPE_ERROR(missing_fields_in_record_expression,
        [<<?Pos(7, 42)
           "The field `x` is missing when constructing an element of type `r('a)`">>,
@@ -467,12 +439,9 @@ failing_contracts() ->
            "The event constructor `BadEvent2` has too many indexed values (max 3)">>])
     , ?TYPE_ERROR(type_clash,
         [<<?Pos(12, 42)
-           "Cannot unify int\n"
-           "         and string\n"
-           "when checking the type of the expression at line 12, column 42\n"
-           "  r.foo() : map(int, string)\n"
-           "against the expected type\n"
-           "  map(string, int)">>])
+           "Cannot unify `int` and `string`\n"
+           "when checking the type of the expression `r.foo() : map(int, string)` "
+           "against the expected type `map(string, int)`">>])
     , ?TYPE_ERROR(not_toplevel_include,
                   [<<?Pos(2, 11)
                      "Include of `included.aes` is not allowed, include only allowed at top level.">>])
@@ -484,98 +453,66 @@ failing_contracts() ->
            "Nested contracts are not allowed. Contract `Con` is not defined at top level.">>])
     , ?TYPE_ERROR(bad_address_literals,
         [<<?Pos(11, 5)
-           "Cannot unify address\n"
-           "         and oracle(int, bool)\n"
-           "when checking the type of the expression at line 11, column 5\n"
-           "  ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt : address\n"
-           "against the expected type\n"
-           "  oracle(int, bool)">>,
+           "Cannot unify `address` and `oracle(int, bool)`\n"
+           "when checking the type of the expression `ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt : address` "
+           "against the expected type `oracle(int, bool)`">>,
          <<?Pos(9, 5)
-           "Cannot unify address\n"
-           "         and Remote\n"
-           "when checking the type of the expression at line 9, column 5\n"
-           "  ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt : address\n"
-           "against the expected type\n"
-           "  Remote">>,
+           "Cannot unify `address` and `Remote`\n"
+           "when checking the type of the expression `ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt : address` "
+           "against the expected type `Remote`">>,
          <<?Pos(7, 5)
-           "Cannot unify address\n"
-           "         and bytes(32)\n"
-           "when checking the type of the expression at line 7, column 5\n"
-           "  ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt : address\n"
-           "against the expected type\n"
-           "  bytes(32)">>,
+           "Cannot unify `address` and `bytes(32)`\n"
+           "when checking the type of the expression `ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt : address` "
+           "against the expected type `bytes(32)`">>,
          <<?Pos(14, 5)
-           "Cannot unify oracle('a, 'b)\n"
-           "         and oracle_query(int, bool)\n"
-           "when checking the type of the expression at line 14, column 5\n"
-           "  ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5 :\n"
-           "    oracle('a, 'b)\n"
-           "against the expected type\n"
-           "  oracle_query(int, bool)">>,
+           "Cannot unify `oracle('a, 'b)` and `oracle_query(int, bool)`\n"
+           "when checking the type of the expression "
+           "`ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5 : oracle('a, 'b)` "
+           "against the expected type `oracle_query(int, bool)`">>,
          <<?Pos(16, 5)
-           "Cannot unify oracle('c, 'd)\n"
-           "         and bytes(32)\n"
-           "when checking the type of the expression at line 16, column 5\n"
-           "  ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5 :\n"
-           "    oracle('c, 'd)\n"
-           "against the expected type\n"
-           "  bytes(32)">>,
+           "Cannot unify `oracle('c, 'd)` and `bytes(32)`\n"
+           "when checking the type of the expression "
+           "`ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5 : oracle('c, 'd)` "
+           "against the expected type `bytes(32)`">>,
          <<?Pos(18, 5)
-           "Cannot unify oracle('e, 'f)\n"
-           "         and Remote\n"
-           "when checking the type of the expression at line 18, column 5\n"
-           "  ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5 :\n"
-           "    oracle('e, 'f)\n"
-           "against the expected type\n"
-           "  Remote">>,
+           "Cannot unify `oracle('e, 'f)` and `Remote`\n"
+           "when checking the type of the expression "
+           "`ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5 : oracle('e, 'f)` "
+           "against the expected type `Remote`">>,
          <<?Pos(21, 5)
-           "Cannot unify oracle_query('g, 'h)\n"
-           "         and oracle(int, bool)\n"
-           "when checking the type of the expression at line 21, column 5\n"
-           "  oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY :\n"
-           "    oracle_query('g, 'h)\n"
-           "against the expected type\n"
-           "  oracle(int, bool)">>,
+           "Cannot unify `oracle_query('g, 'h)` and `oracle(int, bool)`\n"
+           "when checking the type of the expression "
+           "`oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY : oracle_query('g, 'h)` "
+           "against the expected type `oracle(int, bool)`">>,
          <<?Pos(23, 5)
-           "Cannot unify oracle_query('i, 'j)\n"
-           "         and bytes(32)\n"
-           "when checking the type of the expression at line 23, column 5\n"
-           "  oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY :\n"
-           "    oracle_query('i, 'j)\n"
-           "against the expected type\n"
-           "  bytes(32)">>,
+           "Cannot unify `oracle_query('i, 'j)` and `bytes(32)`\n"
+           "when checking the type of the expression "
+           "`oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY : oracle_query('i, 'j)` "
+           "against the expected type `bytes(32)`">>,
          <<?Pos(25, 5)
-           "Cannot unify oracle_query('k, 'l)\n"
-           "         and Remote\n"
-           "when checking the type of the expression at line 25, column 5\n"
-           "  oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY :\n"
-           "    oracle_query('k, 'l)\n"
-           "against the expected type\n"
-           "  Remote">>,
+           "Cannot unify `oracle_query('k, 'l)` and `Remote`\n"
+           "when checking the type of the expression "
+           "`oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY : oracle_query('k, 'l)` "
+           "against the expected type `Remote`">>,
          <<?Pos(28, 5)
-           "The type address is not a contract type\n"
-           "when checking that the contract literal\n"
-           "  ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ\n"
-           "has the type\n"
-           "  address">>,
+           "The type `address` is not a contract type\n"
+           "when checking that the contract literal "
+           "`ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ` "
+           "has the type `address`">>,
          <<?Pos(30, 5)
-           "The type oracle(int, bool) is not a contract type\n"
-           "when checking that the contract literal\n"
-           "  ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ\n"
-           "has the type\n"
-           "  oracle(int, bool)">>,
+           "The type `oracle(int, bool)` is not a contract type\n"
+           "when checking that the contract literal "
+           "`ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ` "
+           "has the type `oracle(int, bool)`">>,
          <<?Pos(32, 5)
-           "The type bytes(32) is not a contract type\n"
-           "when checking that the contract literal\n"
-           "  ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ\n"
-           "has the type\n"
-           "  bytes(32)">>,
+           "The type `bytes(32)` is not a contract type\n"
+           "when checking that the contract literal "
+           "`ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ` "
+           "has the type `bytes(32)`">>,
          <<?Pos(34, 5),
-           "The type address is not a contract type\n"
-           "when checking that the call to\n"
-           "  Address.to_contract\n"
-           "has the type\n"
-           "  address">>])
+           "The type `address` is not a contract type\n"
+           "when checking that the call to `Address.to_contract` "
+           "has the type `address`">>])
     , ?TYPE_ERROR(stateful,
        [<<?Pos(13, 35)
           "Cannot reference stateful function `Chain.spend` in the definition of non-stateful function `fail1`.">>,
@@ -595,20 +532,20 @@ failing_contracts() ->
           "Cannot pass non-zero value argument `1000` in the definition of non-stateful function `fail8`.">>])
     , ?TYPE_ERROR(bad_init_state_access,
        [<<?Pos(11, 5)
-          "The init function should return the initial state as its result and cannot write the state,\n"
+          "The `init` function should return the initial state as its result and cannot write the state, "
           "but it calls\n"
-          "  - set_state (at line 11, column 5), which calls\n"
-          "  - roundabout (at line 8, column 38), which calls\n"
-          "  - put (at line 7, column 39)">>,
+          "  - `set_state` (at line 11, column 5), which calls\n"
+          "  - `roundabout` (at line 8, column 38), which calls\n"
+          "  - `put` (at line 7, column 39)">>,
         <<?Pos(12, 5)
-          "The init function should return the initial state as its result and cannot read the state,\n"
+          "The `init` function should return the initial state as its result and cannot read the state, "
           "but it calls\n"
-          "  - new_state (at line 12, column 5), which calls\n"
-          "  - state (at line 5, column 29)">>,
+          "  - `new_state` (at line 12, column 5), which calls\n"
+          "  - `state` (at line 5, column 29)">>,
         <<?Pos(13, 13)
-          "The init function should return the initial state as its result and cannot read the state,\n"
+          "The `init` function should return the initial state as its result and cannot read the state, "
           "but it calls\n"
-          "  - state (at line 13, column 13)">>])
+          "  - `state` (at line 13, column 13)">>])
     , ?TYPE_ERROR(modifier_checks,
        [<<?Pos(11, 3)
           "The function `all_the_things` cannot be both public and private.">>,
@@ -628,15 +565,18 @@ failing_contracts() ->
           "Use `entrypoint` instead of `function` for public function `foo`: `entrypoint foo : () => unit`">>])
     , ?TYPE_ERROR(list_comp_not_a_list,
       [<<?Pos(2, 36)
-         "Cannot unify int\n         and list('a)\nwhen checking rvalue of list comprehension binding at line 2, column 36\n  1 : int\nagainst type \n  list('a)">>
+         "Cannot unify `int` and `list('a)`\n"
+         "when checking rvalue of list comprehension binding `1 : int` against type `list('a)`">>
       ])
     , ?TYPE_ERROR(list_comp_if_not_bool,
       [<<?Pos(2, 44)
-         "Cannot unify int\n         and bool\nwhen checking the type of the expression at line 2, column 44\n  3 : int\nagainst the expected type\n  bool">>
+         "Cannot unify `int` and `bool`\n"
+         "when checking the type of the expression `3 : int` against the expected type `bool`">>
       ])
     , ?TYPE_ERROR(list_comp_bad_shadow,
       [<<?Pos(2, 53)
-         "Cannot unify int\n         and string\nwhen checking the type of the pattern at line 2, column 53\n  x : int\nagainst the expected type\n  string">>
+         "Cannot unify `int` and `string`\n"
+         "when checking the type of the pattern `x : int` against the expected type `string`">>
       ])
     , ?TYPE_ERROR(map_as_map_key,
        [<<?Pos(5, 47)
@@ -656,7 +596,7 @@ failing_contracts() ->
         [<<?Pos(1, 1) "The definition of 'square' must appear inside a contract or namespace.">>])
     , ?TYPE_ERROR(missing_event_type,
         [<<?Pos(3, 5)
-           "Unbound variable `Chain.event`"
+           "Unbound variable `Chain.event`\n"
            "Did you forget to define the event type?">>])
     , ?TYPE_ERROR(bad_bytes_concat,
         [<<?Pos(12, 40)
@@ -672,12 +612,9 @@ failing_contracts() ->
            "and result type\n"
            "  - 'f  (at line 13, column 14)">>,
          <<?Pos(15, 5)
-           "Cannot unify bytes(26)\n"
-           "         and bytes(25)\n"
-           "when checking the type of the expression at line 15, column 5\n"
-           "  Bytes.concat(x, y) : bytes(26)\n"
-           "against the expected type\n"
-           "  bytes(25)">>,
+           "Cannot unify `bytes(26)` and `bytes(25)`\n"
+           "when checking the type of the expression `Bytes.concat(x, y) : bytes(26)` "
+           "against the expected type `bytes(25)`">>,
          <<?Pos(17, 5)
            "Failed to resolve byte array lengths in call to Bytes.concat with arguments of type\n"
            "  - bytes(6)  (at line 16, column 24)\n"
@@ -736,21 +673,15 @@ failing_contracts() ->
                   [<<?Pos(3, 20)
                      "Arity for id doesn't match. Expected 1, got 0">>,
                    <<?Pos(3, 25)
-                     "Cannot unify int\n"
-                     "         and id\n"
-                     "when checking the type of the expression at line 3, column 25\n"
-                     "  123 : int\n"
-                     "against the expected type\n"
-                     "  id">>,
+                     "Cannot unify `int` and `id`\n"
+                     "when checking the type of the expression `123 : int` "
+                     "against the expected type `id`">>,
                    <<?Pos(4, 20)
                      "Arity for id doesn't match. Expected 1, got 2">>,
                    <<?Pos(4, 35)
-                     "Cannot unify int\n"
-                     "         and id(int, int)\n"
-                     "when checking the type of the expression at line 4, column 35\n"
-                     "  123 : int\n"
-                     "against the expected type\n"
-                     "  id(int, int)">>])
+                     "Cannot unify `int` and `id(int, int)`\n"
+                     "when checking the type of the expression `123 : int` "
+                     "against the expected type `id(int, int)`">>])
     , ?TYPE_ERROR(bad_unnamed_map_update_default,
                   [<<?Pos(4, 17)
                      "Invalid map update with default">>])
@@ -783,25 +714,23 @@ failing_contracts() ->
                   ])
     , ?TYPE_ERROR(bad_number_of_args,
                   [<<?Pos(3, 39)
-                     "Cannot unify () => unit\n"
-                     "         and (int) => 'a\n",
-                     "when checking the application at line 3, column 39 of\n"
-                     "  f : () => unit\n"
+                     "Cannot unify `() => unit` and `(int) => 'a`\n",
+                     "when checking the application of\n"
+                     "  `f : () => unit`\n"
                      "to arguments\n"
-                     "  1 : int">>,
+                     "  `1 : int`">>,
                    <<?Pos(4, 20)
-                     "Cannot unify (int, string) => 'e\n"
-                     "         and (int) => 'd\n"
-                     "when checking the application at line 4, column 20 of\n"
-                     "  g : (int, string) => 'e\n"
+                     "Cannot unify `(int, string) => 'e` and `(int) => 'd`\n"
+                     "when checking the application of\n"
+                     "  `g : (int, string) => 'e`\n"
                      "to arguments\n"
-                     "  1 : int">>,
+                     "  `1 : int`">>,
                    <<?Pos(5, 20)
-                     "Cannot unify (int, string) => 'c\n"
-                     "         and (string) => 'b\n"
-                     "when checking the application at line 5, column 20 of\n"
-                     "  g : (int, string) => 'c\nto arguments\n"
-                     "  \"Litwo, ojczyzno moja\" : string">>
+                     "Cannot unify `(int, string) => 'c` and `(string) => 'b`\n"
+                     "when checking the application of\n"
+                     "  `g : (int, string) => 'c`\n"
+                     "to arguments\n"
+                     "  `\"Litwo, ojczyzno moja\" : string`">>
                   ])
     , ?TYPE_ERROR(bad_state,
                   [<<?Pos(4, 16)
@@ -810,22 +739,22 @@ failing_contracts() ->
                   [<<?Pos(10,18)
                     "Chain.clone requires `ref` named argument of contract type.">>,
                    <<?Pos(11,18)
-                     "Cannot unify (gas : int, value : int, protected : bool) => if(protected, option(void), void)\n         and (gas : int, value : int, protected : bool, int, bool) => 'b\n"
+                     "Cannot unify `(gas : int, value : int, protected : bool) => if(protected, option(void), void)` and `(gas : int, value : int, protected : bool, int, bool) => 'b`\n"
                      "when checking contract construction of type\n  (gas : int, value : int, protected : bool) =>\n    if(protected, option(void), void) (at line 11, column 18)\nagainst the expected type\n  (gas : int, value : int, protected : bool, int, bool) => 'b">>,
                    <<?Pos(12,37)
-                     "Cannot unify int\n         and bool\n"
-                     "when checking named argument\n  gas : int\nagainst inferred type\n  bool">>,
+                     "Cannot unify `int` and `bool`\n"
+                     "when checking named argument `gas : int` against inferred type `bool`">>,
                    <<?Pos(13,18),
                      "Kaboom is not implemented.\n"
-                     "when resolving arguments of variadic function\n  Chain.create">>,
+                     "when resolving arguments of variadic function `Chain.create`">>,
                    <<?Pos(18,18)
-                     "Cannot unify (gas : int, value : int, protected : bool, int, bool) => if(protected, option(void), void)\n         and (gas : int, value : int, protected : bool) => 'a\n"
+                     "Cannot unify `(gas : int, value : int, protected : bool, int, bool) => if(protected, option(void), void)` and `(gas : int, value : int, protected : bool) => 'a`\n"
                      "when checking contract construction of type\n  (gas : int, value : int, protected : bool, int, bool) =>\n    if(protected, option(void), void) (at line 18, column 18)\nagainst the expected type\n  (gas : int, value : int, protected : bool) => 'a">>,
                    <<?Pos(19,42),
-                     "Named argument protected (at line 19, column 42) is not one of the expected named arguments\n  - value : int">>,
+                     "Named argument `protected` is not one of the expected named arguments\n  - `value : int`">>,
                    <<?Pos(20,42),
-                     "Cannot unify int\n         and bool\n"
-                     "when checking named argument\n  value : int\nagainst inferred type\n  bool">>
+                     "Cannot unify `int` and `bool`\n"
+                     "when checking named argument `value : int` against inferred type `bool`">>
                   ])
     , ?TYPE_ERROR(ambiguous_main,
                   [<<?Pos(1,1)
@@ -840,8 +769,10 @@ failing_contracts() ->
                       "Only one main contract can be defined.">>
                    ])
     , ?TYPE_ERROR(using_namespace_ambiguous_name,
-                  [ <<?Pos(2,3)
-                      "Ambiguous name: Xa.f at line 2, column 3\nXb.f at line 5, column 3">>
+                  [ <<?Pos(13,23)
+                      "Ambiguous name `A.f` could be one of\n"
+                      "  - `Xa.f` (at line 2, column 3)\n"
+                      "  - `Xb.f` (at line 5, column 3)">>
                   , <<?Pos(13,23)
                       "Unbound variable `A.f`">>
                   ])
@@ -869,37 +800,39 @@ failing_contracts() ->
                   ])
     , ?TYPE_ERROR(non_boolean_pattern_guard,
                   [<<?Pos(4,24)
-                     "Cannot unify string\n         and bool\nwhen checking the type of the expression at line 4, column 24\n  \"y\" : string\nagainst the expected type\n  bool">>
+                     "Cannot unify `string` and `bool`\n"
+                     "when checking the type of the expression `\"y\" : string` "
+                     "against the expected type `bool`">>
                   ])
     , ?TYPE_ERROR(warnings,
                   [<<?Pos(0, 0)
-                     "The file Triple.aes is included but not used">>,
+                      "The file `Triple.aes` is included but not used.">>,
                    <<?Pos(13, 3)
-                     "The function h is defined at line 13, column 3 but never used">>,
+                     "The function `h` is defined but never used.">>,
                    <<?Pos(19, 3)
-                     "The type unused_type is defined at line 19, column 3 but never used">>,
+                     "The type `unused_type` is defined but never used.">>,
                    <<?Pos(23, 54)
-                     "Negative spend at line 23, column 54">>,
+                     "Negative spend.">>,
                    <<?Pos(27, 9)
-                     "The definition of x at line 27, column 9 shadows an older definition at line 26, column 9">>,
+                     "The definition of `x` shadows an older definition at line 26, column 9.">>,
                    <<?Pos(30, 36)
-                     "Division by zero at line 30, column 36">>,
+                     "Division by zero.">>,
                    <<?Pos(32, 3)
-                     "The function unused_stateful is unnecessarily marked as stateful at line 32, column 3">>,
+                     "The function `unused_stateful` is unnecessarily marked as stateful.">>,
                    <<?Pos(35, 31)
-                     "The variable unused_arg is defined at line 35, column 31 but never used">>,
+                     "The variable `unused_arg` is defined but never used.">>,
                    <<?Pos(36, 9)
-                     "The variable unused_var is defined at line 36, column 9 but never used">>,
+                     "The variable `unused_var` is defined but never used.">>,
                    <<?Pos(41, 3)
-                     "The function unused_function is defined at line 41, column 3 but never used">>,
+                     "The function `unused_function` is defined but never used.">>,
                    <<?Pos(42, 3)
-                     "The function recursive_unused_function is defined at line 42, column 3 but never used">>,
+                     "The function `recursive_unused_function` is defined but never used.">>,
                    <<?Pos(43, 3)
-                     "The function called_unused_function1 is defined at line 43, column 3 but never used">>,
+                     "The function `called_unused_function1` is defined but never used.">>,
                    <<?Pos(44, 3)
-                     "The function called_unused_function2 is defined at line 44, column 3 but never used">>,
+                     "The function `called_unused_function2` is defined but never used.">>,
                    <<?Pos(48, 5)
-                     "Unused return value at line 48, column 5">>
+                     "Unused return value.">>
                   ])
     ].
 

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -330,7 +330,7 @@ failing_contracts() ->
           "  - line 17, column 3">>])
     , ?TYPE_ERROR(type_errors,
        [<<?Pos(17, 23)
-          "Unbound variable zz at line 17, column 23">>,
+          "Unbound variable `zz`">>,
         <<?Pos(26, 9)
           "Cannot unify int\n"
           "         and list(int)\n"
@@ -381,27 +381,25 @@ failing_contracts() ->
           "  - w : int (at line 38, column 13)\n"
           "  - z : string (at line 39, column 10)">>,
         <<?Pos(22, 40)
-          "Not a record type: string\n"
-          "arising from the projection of the field y (at line 22, column 40)">>,
+          "Not a record type: `string`\n"
+          "arising from the projection of the field `y`">>,
         <<?Pos(21, 44)
-          "Not a record type: string\n"
-          "arising from an assignment of the field y (at line 21, column 44)">>,
+          "Not a record type: `string`\n"
+          "arising from an assignment of the field `y`">>,
         <<?Pos(20, 40)
-          "Not a record type: string\n"
-          "arising from an assignment of the field y (at line 20, column 40)">>,
+          "Not a record type: `string`\n"
+          "arising from an assignment of the field `y`">>,
         <<?Pos(19, 37)
-          "Not a record type: string\n"
-          "arising from an assignment of the field y (at line 19, column 37)">>,
+          "Not a record type: `string`\n"
+          "arising from an assignment of the field `y`">>,
         <<?Pos(13, 27)
           "Ambiguous record type with field y (at line 13, column 27) could be one of\n"
           "  - r (at line 4, column 10)\n"
           "  - r' (at line 5, column 10)">>,
         <<?Pos(26, 7)
-          "Repeated name x in pattern\n"
-          "  x :: x (at line 26, column 7)">>,
+          "Repeated name `x` in the pattern `x :: x`">>,
         <<?Pos(44, 14)
-          "Repeated names x, y in pattern\n"
-          "  (x : int, y, x : string, y : bool) (at line 44, column 14)">>,
+          "Repeated names `x`, `y` in the pattern `(x : int, y, x : string, y : bool)`">>,
         <<?Pos(44, 39)
           "Cannot unify int\n"
           "         and string\n"
@@ -417,19 +415,19 @@ failing_contracts() ->
           "against the expected type\n"
           "  string">>,
         <<?Pos(14, 24)
-          "No record type with fields y, z (at line 14, column 24)">>,
+          "No record type with fields `y`, `z`">>,
         <<?Pos(15, 26)
-          "The field z is missing when constructing an element of type r2 (at line 15, column 26)">>,
+          "The field `z` is missing when constructing an element of type `r2`">>,
         <<?Pos(15, 24)
-          "Record type r2 does not have field y (at line 15, column 24)">>,
+          "Record type `r2` does not have field `y`">>,
         <<?Pos(47, 5)
-          "Let binding at line 47, column 5 must be followed by an expression">>,
+          "Let binding must be followed by an expression.">>,
         <<?Pos(50, 5)
-          "Let binding at line 50, column 5 must be followed by an expression">>,
+          "Let binding must be followed by an expression.">>,
         <<?Pos(54, 5)
-          "Let binding at line 54, column 5 must be followed by an expression">>,
+          "Let binding must be followed by an expression.">>,
         <<?Pos(58, 5)
-          "Let binding at line 58, column 5 must be followed by an expression">>,
+          "Let binding must be followed by an expression.">>,
         <<?Pos(63, 5)
           "Cannot unify int\n"
           "         and bool\n"
@@ -449,24 +447,24 @@ failing_contracts() ->
           "when checking that 'init' returns a value of type 'state' at line 5, column 3">>])
     , ?TYPE_ERROR(missing_fields_in_record_expression,
        [<<?Pos(7, 42)
-          "The field x is missing when constructing an element of type r('a) (at line 7, column 42)">>,
+          "The field `x` is missing when constructing an element of type `r('a)`">>,
         <<?Pos(8, 42)
-          "The field y is missing when constructing an element of type r(int) (at line 8, column 42)">>,
+          "The field `y` is missing when constructing an element of type `r(int)`">>,
         <<?Pos(6, 42)
-          "The fields y, z are missing when constructing an element of type r('a) (at line 6, column 42)">>])
+          "The fields `y`, `z` are missing when constructing an element of type `r('a)`">>])
     , ?TYPE_ERROR(namespace_clash,
        [<<?Pos(4, 10)
-          "The contract Call (at line 4, column 10) has the same name as a namespace at (builtin location)">>])
+          "The contract `Call` has the same name as a namespace at (builtin location)">>])
     , ?TYPE_ERROR(bad_events,
         [<<?Pos(9, 25)
-           "The indexed type string (at line 9, column 25) is not a word type">>,
+           "The indexed type `string` is not a word type">>,
          <<?Pos(10, 25)
-           "The indexed type alias_string (at line 10, column 25) equals string which is not a word type">>])
+           "The indexed type `alias_string` equals `string` which is not a word type">>])
     , ?TYPE_ERROR(bad_events2,
         [<<?Pos(9, 7)
-           "The event constructor BadEvent1 (at line 9, column 7) has too many non-indexed values (max 1)">>,
+           "The event constructor `BadEvent1` has too many non-indexed values (max 1)">>,
          <<?Pos(10, 7)
-           "The event constructor BadEvent2 (at line 10, column 7) has too many indexed values (max 3)">>])
+           "The event constructor `BadEvent2` has too many indexed values (max 3)">>])
     , ?TYPE_ERROR(type_clash,
         [<<?Pos(12, 42)
            "Cannot unify int\n"
@@ -477,13 +475,13 @@ failing_contracts() ->
            "  map(string, int)">>])
     , ?TYPE_ERROR(not_toplevel_include,
                   [<<?Pos(2, 11)
-                     "Include of 'included.aes' at line 2, column 11\nnot allowed, include only allowed at top level.">>])
+                     "Include of `included.aes` is not allowed, include only allowed at top level.">>])
     , ?TYPE_ERROR(not_toplevel_namespace,
                   [<<?Pos(2, 13)
-                     "Nested namespaces are not allowed\nNamespace 'Foo' at line 2, column 13 not defined at top level.">>])
+                     "Nested namespaces are not allowed. Namespace `Foo` is not defined at top level.">>])
     , ?TYPE_ERROR(not_toplevel_contract,
         [<<?Pos(2, 12)
-           "Nested contracts are not allowed\nContract 'Con' at line 2, column 12 not defined at top level.">>])
+           "Nested contracts are not allowed. Contract `Con` is not defined at top level.">>])
     , ?TYPE_ERROR(bad_address_literals,
         [<<?Pos(11, 5)
            "Cannot unify address\n"
@@ -580,21 +578,21 @@ failing_contracts() ->
            "  address">>])
     , ?TYPE_ERROR(stateful,
        [<<?Pos(13, 35)
-          "Cannot reference stateful function Chain.spend (at line 13, column 35)\nin the definition of non-stateful function fail1.">>,
+          "Cannot reference stateful function `Chain.spend` in the definition of non-stateful function `fail1`.">>,
         <<?Pos(14, 35)
-          "Cannot reference stateful function local_spend (at line 14, column 35)\nin the definition of non-stateful function fail2.">>,
+          "Cannot reference stateful function `local_spend` in the definition of non-stateful function `fail2`.">>,
         <<?Pos(16, 15)
-          "Cannot reference stateful function Chain.spend (at line 16, column 15)\nin the definition of non-stateful function fail3.">>,
+          "Cannot reference stateful function `Chain.spend` in the definition of non-stateful function `fail3`.">>,
         <<?Pos(20, 31)
-          "Cannot reference stateful function Chain.spend (at line 20, column 31)\nin the definition of non-stateful function fail4.">>,
+          "Cannot reference stateful function `Chain.spend` in the definition of non-stateful function `fail4`.">>,
         <<?Pos(35, 47)
-          "Cannot reference stateful function Chain.spend (at line 35, column 47)\nin the definition of non-stateful function fail5.">>,
+          "Cannot reference stateful function `Chain.spend` in the definition of non-stateful function `fail5`.">>,
         <<?Pos(48, 57)
-          "Cannot pass non-zero value argument 1000 (at line 48, column 57)\nin the definition of non-stateful function fail6.">>,
+          "Cannot pass non-zero value argument `1000` in the definition of non-stateful function `fail6`.">>,
         <<?Pos(49, 56)
-          "Cannot pass non-zero value argument 1000 (at line 49, column 56)\nin the definition of non-stateful function fail7.">>,
+          "Cannot pass non-zero value argument `1000` in the definition of non-stateful function `fail7`.">>,
         <<?Pos(52, 17)
-          "Cannot pass non-zero value argument 1000 (at line 52, column 17)\nin the definition of non-stateful function fail8.">>])
+          "Cannot pass non-zero value argument `1000` in the definition of non-stateful function `fail8`.">>])
     , ?TYPE_ERROR(bad_init_state_access,
        [<<?Pos(11, 5)
           "The init function should return the initial state as its result and cannot write the state,\n"
@@ -613,19 +611,21 @@ failing_contracts() ->
           "  - state (at line 13, column 13)">>])
     , ?TYPE_ERROR(modifier_checks,
        [<<?Pos(11, 3)
-          "The function all_the_things (at line 11, column 3) cannot be both public and private.">>,
+          "The function `all_the_things` cannot be both public and private.">>,
         <<?Pos(3, 3)
-          "Namespaces cannot contain entrypoints (at line 3, column 3). Use 'function' instead.">>,
+          "Namespaces cannot contain entrypoints. Use `function` instead.">>,
         <<?Pos(5, 10)
-          "The contract Remote (at line 5, column 10) has no entrypoints. Since Sophia version 3.2, public\ncontract functions must be declared with the 'entrypoint' keyword instead of\n'function'.">>,
+          "The contract `Remote` has no entrypoints. Since Sophia version 3.2, "
+          "public contract functions must be declared with the `entrypoint` "
+          "keyword instead of `function`.">>,
         <<?Pos(12, 3)
-          "The entrypoint wha (at line 12, column 3) cannot be private. Use 'function' instead.">>,
+          "The entrypoint `wha` cannot be private. Use `function` instead.">>,
         <<?Pos(6, 3)
-          "Use 'entrypoint' for declaration of foo (at line 6, column 3):\n  entrypoint foo : () => unit">>,
+          "Use `entrypoint` for declaration of `foo`: `entrypoint foo : () => unit`">>,
         <<?Pos(10, 3)
-          "Use 'entrypoint' instead of 'function' for public function foo (at line 10, column 3):\n  entrypoint foo() = ()">>,
+          "Use `entrypoint` instead of `function` for public function `foo`: `entrypoint foo() = ()`">>,
         <<?Pos(6, 3)
-          "Use 'entrypoint' instead of 'function' for public function foo (at line 6, column 3):\n  entrypoint foo : () => unit">>])
+          "Use `entrypoint` instead of `function` for public function `foo`: `entrypoint foo : () => unit`">>])
     , ?TYPE_ERROR(list_comp_not_a_list,
       [<<?Pos(2, 36)
          "Cannot unify int\n         and list('a)\nwhen checking rvalue of list comprehension binding at line 2, column 36\n  1 : int\nagainst type \n  list('a)">>
@@ -640,26 +640,23 @@ failing_contracts() ->
       ])
     , ?TYPE_ERROR(map_as_map_key,
        [<<?Pos(5, 47)
-         "Invalid key type\n"
-         "  map(int, int)\n"
+         "Invalid key type `map(int, int)`\n"
          "Map keys cannot contain other maps.">>,
         <<?Pos(6, 31)
-         "Invalid key type\n"
-         "  list(map(int, int))\n"
+         "Invalid key type `list(map(int, int))`\n"
          "Map keys cannot contain other maps.">>,
         <<?Pos(6, 31)
-         "Invalid key type\n"
-         "  lm\n"
+         "Invalid key type `lm`\n"
          "Map keys cannot contain other maps.">>])
     , ?TYPE_ERROR(calling_init_function,
        [<<?Pos(7, 28)
-          "The 'init' function is called exclusively by the create contract transaction\n"
+          "The 'init' function is called exclusively by the create contract transaction "
           "and cannot be called from the contract code.">>])
     , ?TYPE_ERROR(bad_top_level_decl,
         [<<?Pos(1, 1) "The definition of 'square' must appear inside a contract or namespace.">>])
     , ?TYPE_ERROR(missing_event_type,
         [<<?Pos(3, 5)
-           "Unbound variable Chain.event at line 3, column 5\n"
+           "Unbound variable `Chain.event`"
            "Did you forget to define the event type?">>])
     , ?TYPE_ERROR(bad_bytes_concat,
         [<<?Pos(12, 40)
@@ -710,30 +707,30 @@ failing_contracts() ->
             "  - 'a  (at line 18, column 37)">>])
     , ?TYPE_ERROR(wrong_compiler_version,
         [<<?Pos(1, 1)
-           "Cannot compile with this version of the compiler,\n"
+           "Cannot compile with this version of the compiler, "
            "because it does not satisfy the constraint ", Version/binary, " < 1.0">>,
          <<?Pos(2, 1)
-           "Cannot compile with this version of the compiler,\n"
+           "Cannot compile with this version of the compiler, "
            "because it does not satisfy the constraint ", Version/binary, " == 9.9.9">>])
     , ?TYPE_ERROR(interface_with_defs,
          [<<?Pos(2, 3)
             "Contract interfaces cannot contain defined functions or entrypoints.\n"
-            "Fix: replace the definition of 'foo' by a type signature.">>])
+            "Fix: replace the definition of `foo` by a type signature.">>])
     , ?TYPE_ERROR(contract_as_namespace,
          [<<?Pos(5, 28)
-            "Invalid call to contract entrypoint 'Foo.foo'.\n"
-            "It must be called as 'c.foo' for some c : Foo.">>])
+            "Invalid call to contract entrypoint `Foo.foo`.\n"
+            "It must be called as `c.foo` for some `c : Foo`.">>])
     , ?TYPE_ERROR(toplevel_let,
                   [<<?Pos(2, 7)
-                     "Toplevel \"let\" definitions are not supported\n"
-                     "Value this_is_illegal at line 2, column 7 could be replaced by 0-argument function">>])
+                     "Toplevel \"let\" definitions are not supported. "
+                     "Value `this_is_illegal` could be replaced by 0-argument function.">>])
     , ?TYPE_ERROR(empty_typedecl,
                   [<<?Pos(2, 8)
-                     "Empty type declarations are not supported\n"
-                     "Type t at line 2, column 8 lacks a definition">>])
+                     "Empty type declarations are not supported. "
+                     "Type `t` lacks a definition">>])
     , ?TYPE_ERROR(higher_kinded_type,
                   [<<?Pos(2, 35)
-                     "Type 'm is a higher kinded type variable\n"
+                     "Type `'m` is a higher kinded type variable "
                      "(takes another type as an argument)">>])
     , ?TYPE_ERROR(bad_arity,
                   [<<?Pos(3, 20)
@@ -759,24 +756,20 @@ failing_contracts() ->
                      "Invalid map update with default">>])
     , ?TYPE_ERROR(non_functional_entrypoint,
                   [<<?Pos(2, 14)
-                     "f at line 2, column 14 was declared with an invalid type int.\n"
+                     "`f` was declared with an invalid type `int`. "
                      "Entrypoints and functions must have functional types">>])
     , ?TYPE_ERROR(bad_records,
         [<<?Pos(3, 16)
-           "Mixed record fields and map keys in\n"
-           "  {x = 0, [0] = 1}">>,
+           "Mixed record fields and map keys in `{x = 0, [0] = 1}`">>,
          <<?Pos(4, 6)
-           "Mixed record fields and map keys in\n"
-           "  r {x = 0, [0] = 1}">>,
+           "Mixed record fields and map keys in `r {x = 0, [0] = 1}`">>,
          <<?Pos(5, 6)
-           "Empty record/map update\n"
-           "  r {}">>
+           "Empty record/map update `r {}`">>
         ])
     , ?TYPE_ERROR(bad_protected_call,
         [<<?Pos(6, 22)
-           "Invalid 'protected' argument\n"
-           "  (0 : int) == (1 : int) : bool\n"
-           "It must be either 'true' or 'false'.">>
+           "Invalid `protected` argument `(0 : int) == (1 : int) : bool`. "
+           "It must be either `true` or `false`.">>
         ])
     , ?TYPE_ERROR(bad_function_block,
                   [<<?Pos(4, 5)
@@ -850,13 +843,13 @@ failing_contracts() ->
                   [ <<?Pos(2,3)
                       "Ambiguous name: Xa.f at line 2, column 3\nXb.f at line 5, column 3">>
                   , <<?Pos(13,23)
-                      "Unbound variable A.f at line 13, column 23">>
+                      "Unbound variable `A.f`">>
                   ])
     , ?TYPE_ERROR(using_namespace_wrong_scope,
                   [ <<?Pos(19,5)
-                      "Unbound variable f at line 19, column 5">>
+                      "Unbound variable `f`">>
                   , <<?Pos(21,23)
-                      "Unbound variable f at line 21, column 23">>
+                      "Unbound variable `f`">>
                   ])
     , ?TYPE_ERROR(using_namespace_undefined,
                   [<<?Pos(2,3)
@@ -868,11 +861,11 @@ failing_contracts() ->
                   ])
     , ?TYPE_ERROR(using_namespace_hidden_parts,
                   [<<?Pos(8,23)
-                     "Unbound variable g at line 8, column 23">>
+                     "Unbound variable `g`">>
                   ])
     , ?TYPE_ERROR(stateful_pattern_guard,
                   [<<?Pos(8,12)
-                     "Cannot reference stateful function g (at line 8, column 12) in a pattern guard.">>
+                     "Cannot reference stateful function `g` in a pattern guard.">>
                   ])
     , ?TYPE_ERROR(non_boolean_pattern_guard,
                   [<<?Pos(4,24)


### PR DESCRIPTION
Fixes: #354

This PR changes most error messages to:
1. Remove formatting newlines (between sentences).
2. Remove trailing newlines (they will only show when print the error message using `aeso_errors:pp` but not in `#err.msg`).
3. Remove position info (e.g. `at line x, col y`) when it's already available from `#err.pos`.
4. Surround code with \` \` to make it distinguishable from the rest of the error message ("Unbound variable `x`", instead of "Unbound variable x").