### PR TITLE
Add options to enable/disable certain optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Options to enable/disable certain optimizations.
 ### Changed
 ### Removed
 ### Fixed

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -1294,14 +1294,12 @@ optimize_fcode(Code = #{ functions := Funs }, Options) ->
 
 -spec optimize_fun(fcode(), fun_name(), fun_def(), [option()]) -> fun_def().
 optimize_fun(Fcode, Fun, Def = #{ body := Body0 }, Options) ->
-    All = proplists:get_value(optimize_all, Options, true),
-
-    Inliner              = proplists:get_value(optimize_inliner,                Options, All),
-    InlineLocalFunctions = proplists:get_value(optimize_inline_local_functions, Options, All),
-    BindSubexpressions   = proplists:get_value(optimize_bind_subexpressions,    Options, All),
-    LetFloating          = proplists:get_value(optimize_let_floating,           Options, All),
-    Simplifier           = proplists:get_value(optimize_simplifier,             Options, All),
-    DropUnusedLets       = proplists:get_value(optimize_drop_unused_lets,       Options, All),
+    Inliner              = proplists:get_value(optimize_inliner,                Options, true),
+    InlineLocalFunctions = proplists:get_value(optimize_inline_local_functions, Options, true),
+    BindSubexpressions   = proplists:get_value(optimize_bind_subexpressions,    Options, true),
+    LetFloating          = proplists:get_value(optimize_let_floating,           Options, true),
+    Simplifier           = proplists:get_value(optimize_simplifier,             Options, true),
+    DropUnusedLets       = proplists:get_value(optimize_drop_unused_lets,       Options, true),
 
     Body1 = if Inliner              -> inliner   (Fcode, Fun, Body0); true -> Body0 end,
     Body2 = if InlineLocalFunctions -> inline_local_functions(Body1); true -> Body1 end,

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -184,7 +184,7 @@ ast_to_fcode(Code, Options) ->
 optimize(FCode1, Options) ->
     Verbose = lists:member(pp_fcode, Options),
     [io:format("-- Before lambda lifting --\n~s\n\n", [format_fcode(FCode1)]) || Verbose],
-    FCode2 = optimize_fcode(FCode1),
+    FCode2 = optimize_fcode(FCode1, Options),
     [ io:format("-- After optimization --\n~s\n\n", [format_fcode(FCode2)]) || Verbose, FCode2 /= FCode1 ],
     FCode3 = lambda_lift(FCode2),
     [ io:format("-- After lambda lifting --\n~s\n\n", [format_fcode(FCode3)]) || Verbose, FCode3 /= FCode2 ],
@@ -1287,20 +1287,30 @@ lambda_lift_exprs(Layout, As) -> [lambda_lift_expr(Layout, A) || A <- As].
 %% - Constant propagation
 %% - Inlining
 
--spec optimize_fcode(fcode()) -> fcode().
-optimize_fcode(Code = #{ functions := Funs }) ->
-    Code1 = Code#{ functions := maps:map(fun(Name, Def) -> optimize_fun(Code, Name, Def) end, Funs) },
+-spec optimize_fcode(fcode(), [option()]) -> fcode().
+optimize_fcode(Code = #{ functions := Funs }, Options) ->
+    Code1 = Code#{ functions := maps:map(fun(Name, Def) -> optimize_fun(Code, Name, Def, Options) end, Funs) },
     eliminate_dead_code(Code1).
 
--spec optimize_fun(fcode(), fun_name(), fun_def()) -> fun_def().
-optimize_fun(Fcode, Fun, Def = #{ body := Body }) ->
-    %% io:format("Optimizing ~p =\n~s\n", [_Fun, prettypr:format(pp_fexpr(_Body))]),
-    Def#{ body := drop_unused_lets(
-                  simplifier(
-                  let_floating(
-                  bind_subexpressions(
-                  inline_local_functions(
-                  inliner(Fcode, Fun, Body)))))) }.
+-spec optimize_fun(fcode(), fun_name(), fun_def(), [option()]) -> fun_def().
+optimize_fun(Fcode, Fun, Def = #{ body := Body0 }, Options) ->
+    All = proplists:get_value(optimizate_all, Options, true),
+
+    Inliner              = proplists:get_value(optimizate_inliner,                Options, All),
+    InlineLocalFunctions = proplists:get_value(optimizate_inline_local_functions, Options, All),
+    BindSubexpressions   = proplists:get_value(optimizate_bind_subexpressions,    Options, All),
+    LetFloating          = proplists:get_value(optimizate_let_floating,           Options, All),
+    Simplifier           = proplists:get_value(optimizate_simplifier,             Options, All),
+    DropUnusedLets       = proplists:get_value(optimizate_drop_unused_lets,       Options, All),
+
+    Body1 = if Inliner              -> inliner   (Fcode, Fun, Body0); true -> Body0 end,
+    Body2 = if InlineLocalFunctions -> inline_local_functions(Body1); true -> Body1 end,
+    Body3 = if BindSubexpressions   -> bind_subexpressions   (Body2); true -> Body2 end,
+    Body4 = if LetFloating          -> let_floating          (Body3); true -> Body3 end,
+    Body5 = if Simplifier           -> simplifier            (Body4); true -> Body4 end,
+    Body6 = if DropUnusedLets       -> drop_unused_lets      (Body5); true -> Body5 end,
+
+    Def#{ body := Body6 }.
 
 %% --- Inlining ---
 

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -1294,14 +1294,14 @@ optimize_fcode(Code = #{ functions := Funs }, Options) ->
 
 -spec optimize_fun(fcode(), fun_name(), fun_def(), [option()]) -> fun_def().
 optimize_fun(Fcode, Fun, Def = #{ body := Body0 }, Options) ->
-    All = proplists:get_value(optimizate_all, Options, true),
+    All = proplists:get_value(optimize_all, Options, true),
 
-    Inliner              = proplists:get_value(optimizate_inliner,                Options, All),
-    InlineLocalFunctions = proplists:get_value(optimizate_inline_local_functions, Options, All),
-    BindSubexpressions   = proplists:get_value(optimizate_bind_subexpressions,    Options, All),
-    LetFloating          = proplists:get_value(optimizate_let_floating,           Options, All),
-    Simplifier           = proplists:get_value(optimizate_simplifier,             Options, All),
-    DropUnusedLets       = proplists:get_value(optimizate_drop_unused_lets,       Options, All),
+    Inliner              = proplists:get_value(optimize_inliner,                Options, All),
+    InlineLocalFunctions = proplists:get_value(optimize_inline_local_functions, Options, All),
+    BindSubexpressions   = proplists:get_value(optimize_bind_subexpressions,    Options, All),
+    LetFloating          = proplists:get_value(optimize_let_floating,           Options, All),
+    Simplifier           = proplists:get_value(optimize_simplifier,             Options, All),
+    DropUnusedLets       = proplists:get_value(optimize_drop_unused_lets,       Options, All),
 
     Body1 = if Inliner              -> inliner   (Fcode, Fun, Body0); true -> Body0 end,
     Body2 = if InlineLocalFunctions -> inline_local_functions(Body1); true -> Body1 end,

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -709,9 +709,13 @@ tuple(N) -> aeb_fate_ops:tuple(?a, N).
 
 optimize_scode(Funs, Options) ->
     All = proplists:get_value(optimize_all, Options, true),
-    OptimizeScode = proplists:get_value(optimize_scode, Options, All),
-    maps:map(fun(Name, Def) -> optimize_fun(Funs, Name, Def, Options) end,
-             Funs).
+    case proplists:get_value(optimize_scode, Options, All) of
+        true ->
+            maps:map(fun(Name, Def) -> optimize_fun(Funs, Name, Def, Options) end,
+                    Funs);
+        false ->
+            Funs
+    end.
 
 flatten(missing) -> missing;
 flatten(Code)    -> lists:map(fun flatten_s/1, lists:flatten(Code)).

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -708,8 +708,7 @@ tuple(N) -> aeb_fate_ops:tuple(?a, N).
 %%  Optimize
 
 optimize_scode(Funs, Options) ->
-    All = proplists:get_value(optimize_all, Options, true),
-    case proplists:get_value(optimize_scode, Options, All) of
+    case proplists:get_value(optimize_scode, Options, true) of
         true ->
             maps:map(fun(Name, Def) -> optimize_fun(Funs, Name, Def, Options) end,
                     Funs);

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -77,7 +77,7 @@ compile(ChildContracts, FCode, Options) ->
     #{ contract_name := ContractName,
        functions     := Functions } = FCode,
     SFuns  = functions_to_scode(ChildContracts, ContractName, Functions, Options),
-    SFuns1 = proplists:get_value(optimize_scode, Options, true) andalso optimize_scode(SFuns, Options),
+    SFuns1 = optimize_scode(SFuns, Options),
     FateCode = to_basic_blocks(SFuns1),
     ?debug(compile, Options, "~s\n", [aeb_fate_asm:pp(FateCode)]),
     FateCode.
@@ -708,6 +708,8 @@ tuple(N) -> aeb_fate_ops:tuple(?a, N).
 %%  Optimize
 
 optimize_scode(Funs, Options) ->
+    All = proplists:get_value(optimize_all, Options, true),
+    OptimizeScode = proplists:get_value(optimize_scode, Options, All),
     maps:map(fun(Name, Def) -> optimize_fun(Funs, Name, Def, Options) end,
              Funs).
 

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -77,7 +77,7 @@ compile(ChildContracts, FCode, Options) ->
     #{ contract_name := ContractName,
        functions     := Functions } = FCode,
     SFuns  = functions_to_scode(ChildContracts, ContractName, Functions, Options),
-    SFuns1 = optimize_scode(SFuns, Options),
+    SFuns1 = proplists:get_value(optimize_scode, Options, true) andalso optimize_scode(SFuns, Options),
     FateCode = to_basic_blocks(SFuns1),
     ?debug(compile, Options, "~s\n", [aeb_fate_asm:pp(FateCode)]),
     FateCode.


### PR DESCRIPTION
Fixes: #271 

The following options are introduced:

- `optimize_inliner`
- `optimize_inline_local_functions`
- `optimize_bind_subexpressions`
- `optimize_let_floating`
- `optimize_simplifier`
- `optimize_drop_unused_lets`
- `optimize_scode`

By default, all options are implicitly set to `true`, and they should be disabled separately by explicitly setting them to `false`.