### PR TITLE
Return mapping from variables to registers in fate compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     entrypoint spend(x : int) : int = x
     entrypoint f(c : Main) : int = c.spend(10)
   ```
+- Return a mapping from variables to FATE registers in the compilation output.
 ### Changed
 ### Removed
 ### Fixed

--- a/docs/aeso_compiler.md
+++ b/docs/aeso_compiler.md
@@ -53,6 +53,8 @@ The **pp_** options all print to standard output the following:
 
 The option `include_child_contract_symbols` includes the symbols of child contracts functions in the generated fate code. It is turned off by default to avoid making contracts bigger on chain.
 
+The option `debug_info` includes information related to debugging in the compiler output. Currently this option only includes the mapping from variables to registers.
+
 #### Options to control which compiler optimizations should run:
 
 By default all optimizations are turned on, to disable an optimization, it should be

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -1487,7 +1487,7 @@ check_reserved_entrypoints(Funs) ->
 check_fundecl(Env, {fun_decl, Ann, Id = {id, _, Name}, Type = {fun_t, _, _, _, _}}) ->
     Type1 = {fun_t, _, Named, Args, Ret} = check_type(Env, Type),
     TypeSig = {type_sig, Ann, none, Named, Args, Ret},
-    register_implementation(Env, Name),
+    register_implementation(Name),
     {{Name, TypeSig}, {fun_decl, Ann, Id, Type1}};
 check_fundecl(Env, {fun_decl, Ann, Id = {id, _, Name}, Type}) ->
     type_error({fundecl_must_have_funtype, Ann, Id, Type}),
@@ -1495,11 +1495,11 @@ check_fundecl(Env, {fun_decl, Ann, Id = {id, _, Name}, Type}) ->
 
 %% Register the function FunName as implemented by deleting it from the functions
 %% to be implemented table if it is included there, or return true otherwise.
--spec register_implementation(env(), FunName) -> true | no_return() when
+-spec register_implementation(FunName) -> true | no_return() when
       FunName :: string().
-register_implementation(Env, Name) ->
+register_implementation(Name) ->
     case ets_lookup(functions_to_implement, Name) of
-        [{Name, _, {fun_decl, _, _, DeclType}}] ->
+        [{Name, _, {fun_decl, _, _, _}}] ->
             ets_delete(functions_to_implement, Name);
         [] ->
             true;
@@ -1509,9 +1509,9 @@ register_implementation(Env, Name) ->
 
 infer_nonrec(Env, LetFun) ->
     create_constraints(),
-    NewLetFun = {{FunName, FunSig}, _} = infer_letfun(Env, LetFun),
+    NewLetFun = {{FunName, _}, _} = infer_letfun(Env, LetFun),
     check_special_funs(Env, NewLetFun),
-    register_implementation(Env, FunName),
+    register_implementation(FunName),
     solve_then_destroy_and_report_unsolved_constraints(Env),
     Result = {TypeSig, _} = instantiate(NewLetFun),
     print_typesig(TypeSig),
@@ -1541,7 +1541,7 @@ infer_letrec(Env, Defs) ->
     Inferred =
         [ begin
             Res    = {{Name, TypeSig}, _} = infer_letfun(ExtendEnv, LF),
-            register_implementation(Env, Name),
+            register_implementation(Name),
             Got    = proplists:get_value(Name, Funs),
             Expect = typesig_to_fun_t(TypeSig),
             unify(Env, Got, Expect, {check_typesig, Name, Got, Expect}),

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -127,8 +127,7 @@
                     state_layout      := state_layout(),
                     event_type        := ftype() | none,
                     functions         := #{ fun_name() => fun_def() },
-                    payable           := boolean(),
-                    saved_fresh_names := #{ var_name() => var_name() } }.
+                    payable           := boolean() }.
 
 -type type_def() :: fun(([ftype()]) -> ftype()).
 
@@ -150,17 +149,18 @@
 
 -type state_layout() :: {tuple, [state_layout()]} | {reg, state_reg()}.
 
--type env() :: #{ type_env      := type_env(),
-                  fun_env       := fun_env(),
-                  con_env       := con_env(),
-                  child_con_env := child_con_env(),
-                  event_type    => aeso_syntax:typedef(),
-                  builtins      := builtins(),
-                  options       := [option()],
-                  state_layout  => state_layout(),
-                  context       => context(),
-                  vars          => [var_name()],
-                  functions     := #{ fun_name() => fun_def() }
+-type env() :: #{ type_env          := type_env(),
+                  fun_env           := fun_env(),
+                  con_env           := con_env(),
+                  child_con_env     := child_con_env(),
+                  event_type        => aeso_syntax:typedef(),
+                  builtins          := builtins(),
+                  options           := [option()],
+                  state_layout      => state_layout(),
+                  context           => context(),
+                  vars              => [var_name()],
+                  functions         := #{ fun_name() => fun_def() },
+                  saved_fresh_names := #{ var_name() => var_name() }
                }.
 
 -define(HASH_BYTES, 32).
@@ -180,10 +180,10 @@ ast_to_fcode(Code, Options) ->
                         fun (_, FC) -> optimize(FC, Options) end,
                         maps:get(child_con_env, Env1)
                        )},
-    FCode3 = FCode2#{saved_fresh_names => get(saved_fresh_names)},
+    Env3 = Env2#{ saved_fresh_names => get(saved_fresh_names) },
     clear_fresh_names(),
     clear_saved_fresh_names(),
-    {Env2, FCode3}.
+    {Env3, FCode2}.
 
 optimize(FCode1, Options) ->
     Verbose = lists:member(pp_fcode, Options),
@@ -1748,7 +1748,7 @@ clear_saved_fresh_names() ->
 fresh_name_save(Name) ->
     Fresh = fresh_name(),
     Old = get(saved_fresh_names),
-    New = put(saved_fresh_names, Old#{Fresh => Name}),
+    put(saved_fresh_names, Old#{Fresh => Name}),
     Fresh.
 
 -spec fresh_name() -> var_name().

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -239,9 +239,8 @@ init_env(Options) ->
                       ["Chain", "ContractCallTx"]         => #con_tag{ tag = 20, arities = ChainTxArities },
                       ["Chain", "GAAttachTx"]             => #con_tag{ tag = 21, arities = ChainTxArities }
                      },
-       options           => Options,
-       functions         => #{},
-       saved_fresh_names => #{}
+       options   => Options,
+       functions => #{}
     }.
 
 -spec builtins() -> builtins().

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -122,12 +122,12 @@
                       return := ftype(),
                       body   := fexpr() }.
 
--type fcode() :: #{ contract_name     := string(),
-                    state_type        := ftype(),
-                    state_layout      := state_layout(),
-                    event_type        := ftype() | none,
-                    functions         := #{ fun_name() => fun_def() },
-                    payable           := boolean() }.
+-type fcode() :: #{ contract_name := string(),
+                    state_type    := ftype(),
+                    state_layout  := state_layout(),
+                    event_type    := ftype() | none,
+                    functions     := #{ fun_name() => fun_def() },
+                    payable       := boolean() }.
 
 -type type_def() :: fun(([ftype()]) -> ftype()).
 

--- a/src/aeso_ast_to_fcode.erl
+++ b/src/aeso_ast_to_fcode.erl
@@ -180,7 +180,7 @@ ast_to_fcode(Code, Options) ->
                         fun (_, FC) -> optimize(FC, Options) end,
                         maps:get(child_con_env, Env1)
                        )},
-    Env3 = Env2#{ saved_fresh_names => get(saved_fresh_names) },
+    Env3 = Env2#{ saved_fresh_names := get(saved_fresh_names) },
     clear_fresh_names(),
     clear_saved_fresh_names(),
     {Env3, FCode2}.
@@ -237,8 +237,9 @@ init_env(Options) ->
                       ["Chain", "ContractCallTx"]         => #con_tag{ tag = 20, arities = ChainTxArities },
                       ["Chain", "GAAttachTx"]             => #con_tag{ tag = 21, arities = ChainTxArities }
                      },
-       options   => Options,
-       functions => #{}
+       options           => Options,
+       functions         => #{},
+       saved_fresh_names => #{}
     }.
 
 -spec builtins() -> builtins().

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -115,7 +115,7 @@ from_string1(ContractString, Options) ->
      , fcode_env := #{child_con_env := ChildContracts}
      , folded_typed_ast := FoldedTypedAst
      , warnings := Warnings } = string_to_code(ContractString, Options),
-    FateCode = aeso_fcode_to_fate:compile(ChildContracts, FCode, Options),
+    {FateCode, VarsRegs} = aeso_fcode_to_fate:compile(ChildContracts, FCode, Options),
     pp_assembler(FateCode, Options),
     ByteCode = aeb_fate_code:serialize(FateCode, []),
     {ok, Version} = version(),
@@ -126,6 +126,7 @@ from_string1(ContractString, Options) ->
             fate_code => FateCode,
             abi_version => aeb_fate_abi:abi_version(),
             payable => maps:get(payable, FCode),
+            variables_registers => VarsRegs,
             warnings => Warnings
            },
     {ok, maybe_generate_aci(Res, FoldedTypedAst, Options)}.
@@ -185,7 +186,7 @@ check_call1(ContractString0, FunName, Args, Options) ->
         #{fcode := OrgFcode
         , fcode_env := #{child_con_env := ChildContracts}
         , ast := Ast} = string_to_code(ContractString0, Options),
-        FateCode = aeso_fcode_to_fate:compile(ChildContracts, OrgFcode, []),
+        {FateCode, _VarsRegs} = aeso_fcode_to_fate:compile(ChildContracts, OrgFcode, []),
         %% collect all hashes and compute the first name without hash collision to
         SymbolHashes = maps:keys(aeb_fate_code:symbols(FateCode)),
         CallName = first_none_match(?CALL_NAME, SymbolHashes,

--- a/src/aeso_compiler.erl
+++ b/src/aeso_compiler.erl
@@ -112,10 +112,10 @@ from_string(ContractString, Options) ->
 
 from_string1(ContractString, Options) ->
     #{ fcode := FCode
-     , fcode_env := #{child_con_env := ChildContracts}
+     , fcode_env := #{child_con_env := ChildContracts, saved_fresh_names := SavedFreshNames}
      , folded_typed_ast := FoldedTypedAst
      , warnings := Warnings } = string_to_code(ContractString, Options),
-    {FateCode, VarsRegs} = aeso_fcode_to_fate:compile(ChildContracts, FCode, Options),
+    {FateCode, VarsRegs} = aeso_fcode_to_fate:compile(ChildContracts, FCode, SavedFreshNames, Options),
     pp_assembler(FateCode, Options),
     ByteCode = aeb_fate_code:serialize(FateCode, []),
     {ok, Version} = version(),
@@ -184,9 +184,9 @@ check_call1(ContractString0, FunName, Args, Options) ->
     try
         %% First check the contract without the __call function
         #{fcode := OrgFcode
-        , fcode_env := #{child_con_env := ChildContracts}
+        , fcode_env := #{child_con_env := ChildContracts, saved_fresh_names := SavedFreshNames}
         , ast := Ast} = string_to_code(ContractString0, Options),
-        {FateCode, _VarsRegs} = aeso_fcode_to_fate:compile(ChildContracts, OrgFcode, []),
+        {FateCode, _VarsRegs} = aeso_fcode_to_fate:compile(ChildContracts, OrgFcode, SavedFreshNames, []),
         %% collect all hashes and compute the first name without hash collision to
         SymbolHashes = maps:keys(aeb_fate_code:symbols(FateCode)),
         CallName = first_none_match(?CALL_NAME, SymbolHashes,

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -213,7 +213,7 @@ serialize_contract_code(Env, C) ->
         none ->
             Options  = Env#env.options,
             FCode    = maps:get(C, Env#env.child_contracts),
-            FateCode = compile(Env#env.child_contracts, FCode, Options),
+            {FateCode, _} = compile(Env#env.child_contracts, FCode, Options),
             ByteCode = aeb_fate_code:serialize(FateCode, []),
             {ok, Version} = aeso_compiler:version(),
             OriginalSourceCode = proplists:get_value(original_src, Options, ""),

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -138,7 +138,8 @@ get_variables_registers() ->
 add_variables_register(Env = #env{saved_fresh_names = SavedFreshNames}, Name, Register) ->
     Olds = get_variables_registers(),
     RealName = maps:get(Name, SavedFreshNames, Name),
-    New = {Env#env.contract, Env#env.current_function, RealName},
+    FunName = binary_to_list(make_function_name(Env#env.current_function)),
+    New = {Env#env.contract, FunName, RealName},
     put(variables_registers, Olds#{New => Register}).
 
 -define(tvars, '$tvars').

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -125,7 +125,9 @@ function_to_scode(ChildContracts, ContractName, Functions, Name, Attrs0, Args, B
     {ArgTypes, ResType1} = typesig_to_scode(Args, ResType),
     Attrs = Attrs0 -- [stateful], %% Only track private and payable from here.
     Env = init_env(ChildContracts, ContractName, Functions, Name, Args, SavedFreshNames, Options),
-    [ add_variables_register(Env, Arg, Register) || {Arg, Register} <- Env#env.vars ],
+    [ add_variables_register(Env, Arg, Register) ||
+        proplists:get_value(debug_info, Options, false),
+        {Arg, Register} <- Env#env.vars ],
     SCode = to_scode(Env, Body),
     {Attrs, {ArgTypes, ResType1}, SCode}.
 
@@ -205,7 +207,7 @@ next_var(#env{ vars = Vars }) ->
     1 + lists:max([-1 | [J || {_, {var, J}} <- Vars]]).
 
 bind_var(Name, Var, Env = #env{ vars = Vars }) ->
-    add_variables_register(Env, Name, Var),
+    proplists:get_value(debug_info, Env#env.options, false) andalso add_variables_register(Env, Name, Var),
     Env#env{ vars = [{Name, Var} | Vars] }.
 
 bind_local(Name, Env) ->

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -138,7 +138,12 @@ get_variables_registers() ->
 add_variables_register(Env = #env{saved_fresh_names = SavedFreshNames}, Name, Register) ->
     Olds = get_variables_registers(),
     RealName = maps:get(Name, SavedFreshNames, Name),
-    FunName = binary_to_list(make_function_name(Env#env.current_function)),
+    FunName =
+        case Env#env.current_function of
+            event -> "Chain.event";
+            {entrypoint, BinName} -> binary_to_list(BinName);
+            {local_fun, QualName} -> lists:last(QualName)
+        end,
     New = {Env#env.contract, FunName, RealName},
     put(variables_registers, Olds#{New => Register}).
 

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -46,13 +46,13 @@
 -define(void, {var, 9999}).
 
 -record(env, { contract,
-               vars = [],
-               locals = [],
+               vars              = [],
+               locals            = [],
                current_function,
-               tailpos = true,
-               child_contracts = #{},
+               tailpos           = true,
+               child_contracts   = #{},
                saved_fresh_names = #{},
-               options = [] }).
+               options           = [] }).
 
 %% -- Debugging --------------------------------------------------------------
 


### PR DESCRIPTION
This PR will change the result of the compilation to include a mapping from variables to fate registers.

Code example:

```
contract X =
  function g(z) =
    let g = 1
    g + z

  entrypoint f() =
    let g = g(5)
    let h = g + 2
    h + h

main contract C =
  entrypoint f(x) =
    let x = x + x
    let y = x + x
    let x = y + y
    x + x

  entrypoint g() =
    let x = 3
    x + x

  entrypoint q(x) =
    x + 1

  stateful entrypoint xz() =
    let aa : X = Chain.create()
    aa.f()
```

Registers in the compilation result:

```
variables_registers =>
 #{{"C","f","x"} => {var,2},
   {"C","f","y"} => {var,1},
   {"C","g","x"} => {var,0},
   {"C","q","x"} => {arg,0},
   {"C","x","a"} => {var,0},
   {"X",".X.g","g"} => {var,0},
   {"X",".X.g","z"} => {arg,0},
   {"X","f","g"} => {var,0},
   {"X","f","h"} => {var,1}},
```