### PR TITLE
Rename `type_defs` to `typedefs` in ACI to increase compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 - Return a mapping from variables to FATE registers in the compilation output.
 ### Changed
+- Type definitions serialised to ACI as `typedefs` field instead of `type_defs` to increase compatibility.
 ### Removed
 ### Fixed
 

--- a/docs/aeso_aci.md
+++ b/docs/aeso_aci.md
@@ -67,7 +67,7 @@ generates the following JSON structure representing the contract interface:
         }
       ]
     },
-    "type_defs": [
+    "typedefs": [
       {
         "name": "answers",
         "typedef": {
@@ -138,7 +138,7 @@ be included inside another contract.
              state =>
                  #{record =>
                        [#{name => <<"a">>,type => <<"Answers.answers">>}]},
-             type_defs =>
+             typedefs =>
                  [#{name => <<"answers">>,
                     typedef => #{<<"map">> => [<<"string">>,<<"int">>]},
                     vars => []}]}}]}

--- a/src/aeso_aci.erl
+++ b/src/aeso_aci.erl
@@ -91,7 +91,7 @@ encode_contract(Contract = {Head, _, {con, _, Name}, _, _}) when ?IS_CONTRACT_HE
     {Es, Tdefs1} = lists:partition(FilterT(<<"event">>), Tdefs0),
     {Ss, Tdefs}  = lists:partition(FilterT(<<"state">>), Tdefs1),
 
-    C1 = C0#{type_defs => Tdefs},
+    C1 = C0#{typedefs => Tdefs},
 
     C2 = case Es of
              []                 -> C1;
@@ -111,7 +111,7 @@ encode_contract(Contract = {Head, _, {con, _, Name}, _, _}) when ?IS_CONTRACT_HE
 encode_contract(Namespace = {namespace, _, {con, _, Name}, _}) ->
     Tdefs = [ encode_typedef(T) || T <- sort_decls(contract_types(Namespace)) ],
     #{namespace => #{name => encode_name(Name),
-                     type_defs => Tdefs}}.
+                     typedefs => Tdefs}}.
 
 %%  Encode a function definition. Currently we are only interested in
 %%  the interface and type.
@@ -234,7 +234,7 @@ do_render_aci_json(Json) ->
 decode_contract(#{contract := #{name := Name,
                                 kind := Kind,
                                 payable := Payable,
-                                type_defs := Ts0,
+                                typedefs := Ts0,
                                 functions := Fs} = C}) ->
     MkTDef = fun(N, T) -> #{name => N, vars => [], typedef => T} end,
     Ts = [ MkTDef(<<"state">>, maps:get(state, C)) || maps:is_key(state, C) ] ++
@@ -246,7 +246,7 @@ decode_contract(#{contract := #{name := Name,
                        end,
      io_lib:format("~s", [Name])," =\n",
      decode_tdefs(Ts), decode_funcs(Fs)];
-decode_contract(#{namespace := #{name := Name, type_defs := Ts}}) when Ts /= [] ->
+decode_contract(#{namespace := #{name := Name, typedefs := Ts}}) when Ts /= [] ->
     ["namespace ", io_lib:format("~s", [Name])," =\n",
      decode_tdefs(Ts)];
 decode_contract(_) -> [].

--- a/test/aeso_aci_tests.erl
+++ b/test/aeso_aci_tests.erl
@@ -21,7 +21,7 @@ test_cases(1) ->
 		 "  payable stateful entrypoint a(i : int) = i+1\n">>,
     MapACI = #{contract =>
 		   #{name => <<"C">>,
-		     type_defs => [],
+		     typedefs => [],
          payable => true,
          kind => contract_main,
 		     functions =>
@@ -43,7 +43,7 @@ test_cases(2) ->
     MapACI = #{contract =>
                    #{name => <<"C">>, payable => false,
                      kind => contract_main,
-                     type_defs =>
+                     typedefs =>
                          [#{name => <<"allan">>,
                             typedef => <<"int">>,
                             vars => []}],
@@ -76,7 +76,7 @@ test_cases(3) ->
 		     name => <<"C">>, payable => false, kind => contract_main,
          event => #{variant => [#{<<"SingleEventDefined">> => []}]},
          state => <<"unit">>,
-		     type_defs =>
+		     typedefs =>
              [#{name => <<"bert">>,
                 typedef =>
                     #{variant =>


### PR DESCRIPTION
related to https://github.com/aeternity/aepp-sdk-js/issues/1681

Also, it would be consistent with `typedef` that appears in the source code.