### PR TITLE
fix: use latest pygments version to generate docs

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -2,4 +2,4 @@ mkdocs==1.2.4
 mkdocs-simple-hooks==0.1.5
 mkdocs-material==7.3.6
 mike==1.1.2
-pygments==2.12.0
+pygments==2.14.0


### PR DESCRIPTION
@ghallak @hanssv I am sorry but I probably didn't check the dependency on pygments with last PR

```
ERROR: Cannot install -r .github/workflows/requirements.txt (line 3) and pygments==2.12.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested pygments==2.12.0
    mkdocs-material 9.0.9 depends on pygments>=2.14
```

this should be fixed now