### PR TITLE
[Ceres]: document changes to Auth.tx_hash

### DIFF
--- a/docs/sophia_stdlib.md
+++ b/docs/sophia_stdlib.md
@@ -266,7 +266,10 @@ namespace Chain =
 Auth.tx_hash : option(hash)
 ```
 
-Gets the transaction hash during authentication.
+Gets the transaction hash during authentication. Note: `Auth.tx_hash`
+computation differs between protocol versions (changed in Ceres!), see
+[aeserialisation](https://github.com/aeternity/protocol/blob/master/serializations.md)
+specification for details.
 
 
 ### Bits


### PR DESCRIPTION
This PR is supported by the Æternity Crypto Foundation