### PR TITLE
Unify typesigs when implementing interface funs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+- Fixed a bug with polymorphism that allowed functions with the same name but different type to be considered as implementations for their corresponding interface function.
 
 ## [7.2.1]
 ### Fixed

--- a/test/aeso_compiler_tests.erl
+++ b/test/aeso_compiler_tests.erl
@@ -871,10 +871,10 @@ failing_contracts() ->
                      "Trying to implement or extend an undefined interface `Z`">>
                   ])
     , ?TYPE_ERROR(polymorphism_contract_interface_same_name_different_type,
-                  [<<?Pos(9,5)
-                     "Duplicate definitions of `f` at\n"
-                     "  - line 8, column 5\n"
-                     "  - line 9, column 5">>])
+                  [<<?Pos(5,5)
+                     "Cannot unify `char` and `int`\n"
+                     "when implementing the entrypoint `f` from the interface `I1`">>
+                  ])
     , ?TYPE_ERROR(polymorphism_contract_missing_implementation,
                   [<<?Pos(4,20)
                      "Unimplemented entrypoint `f` from the interface `I1` in the contract `I2`">>


### PR DESCRIPTION

This PR should prevent this code from compiling

```
include "Frac.aes"

contract interface Interface =
 entrypoint example: (Frac.frac) => Frac.frac

main contract Example: Interface =
  entrypoint example(x : int): int = x
```
