### PR TITLE
Improve constraint solving

### DIFF
--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -3073,7 +3073,8 @@ unify0(Env, A, B, Variance, When) ->
 unify1(_Env, {uvar, _, R}, {uvar, _, R}, _Variance, _When) ->
     true;
 unify1(_Env, {uvar, _, _}, {fun_t, _, _, var_args, _}, _Variance, When) ->
-    type_error({unify_varargs, When});
+    type_error({unify_varargs, When}),
+    false;
 unify1(Env, {uvar, A, R}, T, _Variance, When) ->
     case occurs_check(R, T) of
         true ->
@@ -3134,9 +3135,11 @@ unify1(Env, {if_t, _, {id, _, Id}, Then1, Else1}, {if_t, _, {id, _, Id}, Then2, 
     unify0(Env, Else1, Else2, Variance, When);
 
 unify1(_Env, {fun_t, _, _, _, _}, {fun_t, _, _, var_args, _}, _Variance, When) ->
-    type_error({unify_varargs, When});
+    type_error({unify_varargs, When}),
+    false;
 unify1(_Env, {fun_t, _, _, var_args, _}, {fun_t, _, _, _, _}, _Variance, When) ->
-    type_error({unify_varargs, When});
+    type_error({unify_varargs, When}),
+    false;
 unify1(Env, {fun_t, _, Named1, Args1, Result1}, {fun_t, _, Named2, Args2, Result2}, Variance, When)
   when length(Args1) == length(Args2) ->
     unify0(Env, Named1, Named2, opposite_variance(Variance), When) andalso
@@ -3158,7 +3161,7 @@ unify1(Env, {tuple_t, _, As}, {tuple_t, _, Bs}, Variance, When)
   when length(As) == length(Bs) ->
     unify0(Env, As, Bs, Variance, When);
 unify1(Env, {named_arg_t, _, Id1, Type1, _}, {named_arg_t, _, Id2, Type2, _}, Variance, When) ->
-    unify1(Env, Id1, Id2, Variance, {arg_name, Id1, Id2, When}),
+    unify1(Env, Id1, Id2, Variance, {arg_name, Id1, Id2, When}) andalso
     unify1(Env, Type1, Type2, Variance, When);
 %% The grammar is a bit inconsistent about whether types without
 %% arguments are represented as applications to an empty list of

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -4119,8 +4119,8 @@ pp_when({if_branches, Then, ThenType0, Else, ElseType0}) ->
     Branches = [ {Then, ThenType} | [ {B, ElseType} || B <- if_branches(Else) ] ],
     {pos(element(1, hd(Branches))),
      io_lib:format("when comparing the types of the if-branches\n"
-                   "~s", [ [ io_lib:format("~s (at ~s)\n", [pp_typed("  - ", B, BType), pp_loc(B)])
-                           || {B, BType} <- Branches ] ])};
+                   "~s", [string:join([ io_lib:format("~s (at ~s)", [pp_typed("  - ", B, BType), pp_loc(B)])
+                                       || {B, BType} <- Branches ], "\n")])};
 pp_when({case_pat, Pat, PatType0, ExprType0}) ->
     {PatType, ExprType} = instantiate({PatType0, ExprType0}),
     {pos(Pat),


### PR DESCRIPTION
Fingers itched... This solves one actual problem (on Ceres branch once rebased) where three constraints depended on each other and the current implementation only made two iterations.

The rewrite should be more general and easier to further change if necessary. Would be nice to separate solving and error reporting further - but lets save that for another rainy day.

This PR is supported by the Æternity Crypto Foundation
