### PR TITLE
Improve independence analysis in code optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - Fixed a bug with polymorphism that allowed functions with the same name but different type to be considered as implementations for their corresponding interface function.
+- Fixed a bug in the byte code optimization that incorrectly reordered dependent instructions.
 
 ## [7.2.1]
 ### Fixed

--- a/src/aeso_fcode_to_fate.erl
+++ b/src/aeso_fcode_to_fate.erl
@@ -1141,11 +1141,16 @@ independent({i, _, I}, {i, _, J}) ->
     StackI = lists:member(?a, [WI | RI]),
     StackJ = lists:member(?a, [WJ | RJ]),
 
-    if  WI == pc; WJ == pc   -> false;     %% no jumps
-        not (PureI or PureJ) -> false;     %% at least one is pure
-        StackI and StackJ    -> false;     %% cannot both use the stack
-        WI == WJ             -> false;     %% cannot write to the same register
-        true                 ->
+    ReadStoreI = [] /= [ x || {store, _} <- RI ],
+    ReadStoreJ = [] /= [ x || {store, _} <- RJ ],
+
+    if  WI == pc; WJ == pc       -> false;  %% no jumps
+        not (PureI or PureJ)     -> false;  %% at least one is pure
+        StackI and StackJ        -> false;  %% cannot both use the stack
+        WI == WJ                 -> false;  %% cannot write to the same register
+        ReadStoreI and not PureJ -> false;  %% can't read store/state if other is impure
+        ReadStoreJ and not PureI -> false;  %% can't read store/state if other is impure
+        true                     ->
             %% and cannot write to each other's inputs
             not lists:member(WI, RJ) andalso
             not lists:member(WJ, RI)


### PR DESCRIPTION
There is an omission in the logic checking whether two byte code instructions are independent - as demonstrated by #482 

This adds a check that an instruction reading the store/state is not pushed past an impure instruction (for example a function call).

This results in:
```
FUNCTION foo( integer) : integer
  ;; BB : 0
          MAP_LOOKUP var0 store1 arg0
          PUSH arg0
          CALL "IBB"
  ;; BB : 1
          POP var9999
          RETURNR var0
```
Fixes #482 

This PR is supported by the Æternity Crypto Foundation