### PR TITLE
Fix parser/pretty printer for OTP-27 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for OTP-27 - no changes in behavior.
 ### Changed
 ### Removed
 ### Fixed

--- a/priv/stdlib/List.aes
+++ b/priv/stdlib/List.aes
@@ -282,9 +282,9 @@ namespace List =
   private function
     asc : (('a, 'a) => bool, 'a, list('a), list('a)) => list(list('a))
     asc(lt, x, acc, h::t) =
-      if(lt(h, x)) List.reverse(x::acc) :: monotonic_subs(lt, h::t)
+      if(lt(h, x)) reverse(x::acc) :: monotonic_subs(lt, h::t)
       else asc(lt, h, x::acc, t)
-    asc(_, x, acc, []) = [List.reverse(x::acc)]
+    asc(_, x, acc, []) = [reverse(x::acc)]
 
   /** Merges list of sorted lists
    */

--- a/src/aeso_pretty.erl
+++ b/src/aeso_pretty.erl
@@ -418,7 +418,7 @@ stmt_p({'if', _, Cond, Then}) ->
     block_expr(200, beside(text("if"), paren(expr(Cond))), Then);
 stmt_p({elif, _, Cond, Then}) ->
     block_expr(200, beside(text("elif"), paren(expr(Cond))), Then);
-stmt_p({else, Else}) ->
+stmt_p({'else', Else}) ->
     HideGenerated = not show_generated(),
     case aeso_syntax:get_ann(origin, Else) of
         system when HideGenerated -> empty();
@@ -533,5 +533,5 @@ get_elifs(If = {'if', Ann, Cond, Then, Else}, Elifs) ->
         elif -> get_elifs(Else, [{elif, Ann, Cond, Then} | Elifs]);
         _    -> {lists:reverse(Elifs), If}
     end;
-get_elifs(Else, Elifs) -> {lists:reverse(Elifs), {else, Else}}.
+get_elifs(Else, Elifs) -> {lists:reverse(Elifs), {'else', Else}}.
 


### PR DESCRIPTION
In OTP-27 else is made a keyword, so needs to be 'else'.

This PR is supported by Æternity Foundation.