### PR TITLE
Allow self-qualification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+- Allow self-qualification, i.e. referencing `X.foo` when in namespace `X`.
 
 ## [8.0.0-rc1]
 ### Added

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -1161,7 +1161,7 @@ infer_contract(Env0, What, Defs0, Options) ->
     _         = bind_funs(lists:map(FunBind, Functions), #env{}),
     FunMap    = maps:from_list([ {FunName(Def), Def} || Def <- Functions ]),
     check_reserved_entrypoints(FunMap),
-    DepGraph  = maps:map(fun(_, Def) -> aeso_syntax_utils:used_ids(Def) end, FunMap),
+    DepGraph  = maps:map(fun(_, Def) -> aeso_syntax_utils:used_ids(Env3#env.namespace, Def) end, FunMap),
     SCCs      = aeso_utils:scc(DepGraph),
     {Env4, Defs1} = check_sccs(Env3, FunMap, SCCs, []),
     %% Remove namespaces used in the current namespace
@@ -2953,7 +2953,6 @@ record_type_name({app_t, _Attrs, RecId, _Args}) when ?is_type_id(RecId) ->
 record_type_name(RecId) when ?is_type_id(RecId) ->
     RecId;
 record_type_name(_Other) ->
-    %% io:format("~p is not a record type\n", [Other]),
     {id, [{origin, system}], "not_a_record_type"}.
 
 solve_for_uvar(Env, UVar = {uvar, Attrs, _}, Fields0) ->
@@ -3562,7 +3561,6 @@ create_type_errors() ->
 
 destroy_and_report_type_errors(Env) ->
     Errors0 = lists:reverse(ets_tab2list(type_errors)),
-    %% io:format("Type errors now: ~p\n", [Errors0]),
     ets_delete(type_errors),
     Errors  = [ mk_error(unqualify(Env, Err)) || Err <- Errors0 ],
     aeso_errors:throw(Errors).  %% No-op if Errors == []

--- a/src/aeso_syntax_utils.erl
+++ b/src/aeso_syntax_utils.erl
@@ -119,11 +119,7 @@ used_ids(Ns, E) ->
     [ lists:last(Xs) || {{term, Xs}, _} <- used(E), in_ns(Xs, Ns) ].
 
 in_ns([_], _) -> true;
-in_ns(Xs, Ns) -> in_ns_(Xs, Ns).
-
-in_ns_([_], [])            -> true;
-in_ns_([X | Xs], [X | Ns]) -> in_ns_(Xs, Ns);
-in_ns_(_, _)               -> false.
+in_ns(Xs, Ns) -> lists:droplast(Xs) == Ns.
 
 used_types([Top] = _CurrentNS, T) ->
     F = fun({{type, [X]}, _}) -> [X];

--- a/src/aeso_syntax_utils.erl
+++ b/src/aeso_syntax_utils.erl
@@ -6,7 +6,7 @@
 %%%-------------------------------------------------------------------
 -module(aeso_syntax_utils).
 
--export([used_ids/1, used_types/2, used/1]).
+-export([used_ids/1, used_ids/2, used_types/2, used/1]).
 
 -record(alg, {zero, plus, scoped}).
 
@@ -110,8 +110,20 @@ fold(Alg = #alg{zero = Zero, plus = Plus, scoped = Scoped}, Fun, K, X) ->
 
 %% Name dependencies
 
+%% Used ids, top level
 used_ids(E) ->
-    [ X || {{term, [X]}, _} <- used(E) ].
+    used_ids([], E).
+
+%% Used ids, top level or in (current) namespace
+used_ids(Ns, E) ->
+    [ lists:last(Xs) || {{term, Xs}, _} <- used(E), in_ns(Xs, Ns) ].
+
+in_ns([_], _) -> true;
+in_ns(Xs, Ns) -> in_ns_(Xs, Ns).
+
+in_ns_([_], [])            -> true;
+in_ns_([X | Xs], [X | Ns]) -> in_ns_(Xs, Ns);
+in_ns_(_, _)               -> false.
 
 used_types([Top] = _CurrentNS, T) ->
     F = fun({{type, [X]}, _}) -> [X];


### PR DESCRIPTION
Allow referring to `foo` in namespace `X` as `X.foo` when already inside `X`. 

This used to result in an error if dependencies happened to be analyzed in the wrong order...

This PR is supported by Æternity Foundation.