### PR TITLE
Docs: Fix return value type in Auction example

### DIFF
--- a/docs/sophia_stdlib.md
+++ b/docs/sophia_stdlib.md
@@ -687,8 +687,8 @@ Example usage:
 ```
 payable contract interface Auction =
   entrypoint init : (int, string) => void
-  stateful payable entrypoint buy : (int) => ()
-  stateful entrypoint sell : (int) => ()
+  stateful payable entrypoint buy : (int) => unit
+  stateful entrypoint sell : (int) => unit
 
 main contract Market =
   type state = list(Auction)


### PR DESCRIPTION
Otherwise I'm getting error

> Invalid type `()`. The syntax of tuple types changed in Sophia version 4.0. Did you mean `unit`

This PR is supported by the Æternity Foundation