### PR TITLE
Update the docs

### DIFF
--- a/docs/sophia_features.md
+++ b/docs/sophia_features.md
@@ -540,6 +540,7 @@ Sophia has the following types:
 | Type                 | Description                                                                                 | Example                                                      |
 |----------------------|---------------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | int                  | A 2-complement integer                                                                      | ```-1```                                                     |
+| char | A single character (the underlying representation is an integer) | ```'g'```
 | address              | æternity address, 32 bytes                                                                 | ```Call.origin```                                            |
 | bool                 | A Boolean                                                                                   | ```true```                                                   |
 | bits                 | A bit field                                                                                 | ```Bits.none```                                              |
@@ -555,7 +556,6 @@ Sophia has the following types:
 | event                | An append only list of blockchain events (or log entries)                                   | ```datatype event = EventX(indexed int, string)```           |
 | hash                 | A 32-byte hash - equivalent to `bytes(32)`                                                  |                                                              |
 | signature            | A signature - equivalent to `bytes(64)`                                                     |                                                              |
-| Chain.ttl            | Time-to-live (fixed height or relative to current block)                                    | ```FixedTTL(1050)``` ```RelativeTTL(50)```                   |
 | oracle('a, 'b)       | And oracle answering questions of type 'a with answers of type 'b                           | ```Oracle.register(acct, qfee, ttl)```                       |
 | oracle_query('a, 'b) | A specific oracle query                                                                     | ```Oracle.query(o, q, qfee, qttl, rttl)```                   |
 | contract             | A user defined, typed, contract address                                                     | ```function call_remote(r : RemoteContract) = r.fun()```     |

--- a/docs/sophia_stdlib.md
+++ b/docs/sophia_stdlib.md
@@ -484,13 +484,6 @@ Call.gas_price : int
 
 The gas price of the current call.
 
-#### mulmod
-```
-Int.mulmod : (a : int, b : int, q : int) : int
-```
-
-Combined multiplication and modulus, returns `(a * b) mod q`.
-
 #### fee
 ```
 Call.fee : int
@@ -501,7 +494,7 @@ The fee of the current call.
 
 #### gas_left
 ```
-Call.gas_left() : int
+Call.gas_left : int
 ```
 
 The amount of gas left for the current call.
@@ -512,6 +505,20 @@ The amount of gas left for the current call.
 Values and functions related to the chain itself and other entities that live on it.
 
 #### Types
+
+##### ttl
+
+Time-to-live (fixed height or relative to current block).
+
+Note that this type is a special case, where the type `ttl` is inside the
+`Chain` scope, but the constrctors `FixedTTL(int)` and `RelativeTTL(int)` are
+not. Meaning that the type `ttl` should be qualified with `Chain` when it is
+used (i.e. `Chain.ttl`), but the constructors should not be qualified (i.e.
+`FixedTTL(1050)` should be used rather than `Chain.FixedTTL(1050)`).
+
+```
+Chain.ttl = FixedTTL(int) | RelativeTTL(int)
+```
 
 ##### tx
 ```
@@ -573,7 +580,7 @@ the current generation.
 
 ##### block_height
 ```
-Chain.block_height : int"
+Chain.block_height : int
 ```
 
 The height of the current block (i.e. the block in which the current call will be included).
@@ -732,21 +739,12 @@ Chain.gas_limit : int
 The gas limit of the current block.
 
 
-##### network\_id
+##### network_id
 ```
-Chain.network\_id : string
+Chain.network_id : string
 ```
 
 The network id of the chain.
-
-
-#### poseidon
-```
-Crypto.poseidon(x1 : int, x2 : int) : int
-```
-
-Hash two integers (in the scalar field of BLS12-381) to another integer (in the scalar
-field of BLS12-281). This is a ZK/SNARK-friendly hash function.
 
 
 ##### spend
@@ -769,7 +767,7 @@ The timestamp of the current block (unix time, milliseconds).
 ### Char
 
 #### to_int
- ```
+```
 Char.to_int(c : char) : int
 ```
 
@@ -780,7 +778,7 @@ Returns the UTF-8 codepoint of a character
 
 ```
 Char.from_int(i : int) : option(char)
- ```
+```
 
 Opposite of [to_int](#to_int). Returns `None` if the integer doesn't correspond to a single (normalized) codepoint.
 
@@ -839,6 +837,15 @@ Crypto.blake2b(x : 'a) : hash
 Hash any object to blake2b
 
 
+#### poseidon
+```
+Crypto.poseidon(x1 : int, x2 : int) : int
+```
+
+Hash two integers (in the scalar field of BLS12-381) to another integer (in the scalar
+field of BLS12-281). This is a ZK/SNARK-friendly hash function.
+
+
 #### verify_sig
 ```
 Crypto.verify_sig(msg : bytes(), pubkey : address, sig : signature) : bool
@@ -880,6 +887,13 @@ Verifies a standard 64-byte ECDSA signature (`R || S`).
 
 
 ### Int
+
+#### mulmod
+```
+Int.mulmod : (a : int, b : int, q : int) : int
+```
+
+Combined multiplication and modulus, returns `(a * b) mod q`.
 
 #### to\_str
 ```

--- a/src/aeso_ast_infer_types.erl
+++ b/src/aeso_ast_infer_types.erl
@@ -28,6 +28,7 @@
 -type utype() :: {fun_t, aeso_syntax:ann(), named_args_t(), [utype()] | var_args, utype()}
                | {app_t, aeso_syntax:ann(), utype(), [utype()]}
                | {tuple_t, aeso_syntax:ann(), [utype()]}
+               | {bytes_t, aeso_syntax:ann(), non_neg_integer() | any}
                | aeso_syntax:id()  | aeso_syntax:qid()
                | aeso_syntax:con() | aeso_syntax:qcon()  %% contracts
                | aeso_syntax:tvar()


### PR DESCRIPTION
* Add `char` to the list of Sophia types

* Move `Chain.ttl` to stdlib docs instead of Sophia types

* Add a note about `Chain.ttl` being a special case

* Make `Call.gas_left` a constant instead of a zero-argument function

* Move the function `Int.mulmod` to its right place in stdlib docs

* Move the function `Crypto.poseidon` to its right place in stdlib docs

* Fix typos in 'sophia_stdlib.md'

* Add `bytes_t` to `utype()` in the type checker